### PR TITLE
Add disabling of boarderFunctionality

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -552,13 +552,15 @@ public class PhotoEditor implements BrushViewChangeListener {
     private void clearTextHelperBox() {
         for (int i = 0; i < parentView.getChildCount(); i++) {
             View childAt = parentView.getChildAt(i);
-            FrameLayout frmBorder = childAt.findViewById(R.id.frmBorder);
-            if (frmBorder != null && isBorderFunctionalityEnabled) {
-                frmBorder.setBackgroundResource(0);
-            }
-            ImageView imgClose = childAt.findViewById(R.id.imgPhotoEditorClose);
-            if (imgClose != null) {
-                imgClose.setVisibility(View.GONE);
+            if(isBorderFunctionalityEnabled) {
+                FrameLayout frmBorder = childAt.findViewById(R.id.frmBorder);
+                if (frmBorder != null) {
+                    frmBorder.setBackgroundResource(0);
+                }
+                ImageView imgClose = childAt.findViewById(R.id.imgPhotoEditorClose);
+                if (imgClose != null) {
+                    imgClose.setVisibility(View.GONE);
+                }
             }
         }
     }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -51,6 +51,7 @@ public class PhotoEditor implements BrushViewChangeListener {
     private List<View> redoViews;
     private OnPhotoEditorListener mOnPhotoEditorListener;
     private boolean isTextPinchZoomable;
+    private boolean isBorderFunctionalityEnabled;
     private Typeface mDefaultTextTypeface;
     private Typeface mDefaultEmojiTypeface;
 
@@ -62,6 +63,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         this.deleteView = builder.deleteView;
         this.brushDrawingView = builder.brushDrawingView;
         this.isTextPinchZoomable = builder.isTextPinchZoomable;
+        this.isBorderFunctionalityEnabled = builder.isBorderFunctionalityEnabled;
         this.mDefaultTextTypeface = builder.textTypeface;
         this.mDefaultEmojiTypeface = builder.emojiTypeface;
         mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -88,10 +90,12 @@ public class PhotoEditor implements BrushViewChangeListener {
         multiTouchListener.setOnGestureControl(new MultiTouchListener.OnGestureControl() {
             @Override
             public void onClick() {
-                boolean isBackgroundVisible = frmBorder.getTag() != null && (boolean) frmBorder.getTag();
-                frmBorder.setBackgroundResource(isBackgroundVisible ? 0 : R.drawable.rounded_border_tv);
-                imgClose.setVisibility(isBackgroundVisible ? View.GONE : View.VISIBLE);
-                frmBorder.setTag(!isBackgroundVisible);
+                if (isBorderFunctionalityEnabled) {
+                    boolean isBackgroundVisible = frmBorder.getTag() != null && (boolean) frmBorder.getTag();
+                    frmBorder.setBackgroundResource(isBackgroundVisible ? 0 : R.drawable.rounded_border_tv);
+                    imgClose.setVisibility(isBackgroundVisible ? View.GONE : View.VISIBLE);
+                    frmBorder.setTag(!isBackgroundVisible);
+                }
             }
 
             @Override
@@ -99,6 +103,12 @@ public class PhotoEditor implements BrushViewChangeListener {
 
             }
         });
+
+        if (!isBorderFunctionalityEnabled) {
+            imgClose.setVisibility(View.GONE);
+            frmBorder.setBackgroundResource(0);
+            frmBorder.setTag(false);
+        }
 
         imageRootView.setOnTouchListener(multiTouchListener);
 
@@ -143,10 +153,12 @@ public class PhotoEditor implements BrushViewChangeListener {
         multiTouchListener.setOnGestureControl(new MultiTouchListener.OnGestureControl() {
             @Override
             public void onClick() {
-                boolean isBackgroundVisible = frmBorder.getTag() != null && (boolean) frmBorder.getTag();
-                frmBorder.setBackgroundResource(isBackgroundVisible ? 0 : R.drawable.rounded_border_tv);
-                imgClose.setVisibility(isBackgroundVisible ? View.GONE : View.VISIBLE);
-                frmBorder.setTag(!isBackgroundVisible);
+                if (isBorderFunctionalityEnabled) {
+                    boolean isBackgroundVisible = frmBorder.getTag() != null && (boolean) frmBorder.getTag();
+                    frmBorder.setBackgroundResource(isBackgroundVisible ? 0 : R.drawable.rounded_border_tv);
+                    imgClose.setVisibility(isBackgroundVisible ? View.GONE : View.VISIBLE);
+                    frmBorder.setTag(!isBackgroundVisible);
+                }
             }
 
             @Override
@@ -158,6 +170,12 @@ public class PhotoEditor implements BrushViewChangeListener {
                 }
             }
         });
+
+        if (!isBorderFunctionalityEnabled) {
+            imgClose.setVisibility(View.GONE);
+            frmBorder.setBackgroundResource(0);
+            frmBorder.setTag(false);
+        }
 
         textRootView.setOnTouchListener(multiTouchListener);
         addViewToParent(textRootView, ViewType.TEXT);
@@ -230,16 +248,25 @@ public class PhotoEditor implements BrushViewChangeListener {
         multiTouchListener.setOnGestureControl(new MultiTouchListener.OnGestureControl() {
             @Override
             public void onClick() {
-                boolean isBackgroundVisible = frmBorder.getTag() != null && (boolean) frmBorder.getTag();
-                frmBorder.setBackgroundResource(isBackgroundVisible ? 0 : R.drawable.rounded_border_tv);
-                imgClose.setVisibility(isBackgroundVisible ? View.GONE : View.VISIBLE);
-                frmBorder.setTag(!isBackgroundVisible);
+                if (isBorderFunctionalityEnabled) {
+                    boolean isBackgroundVisible = frmBorder.getTag() != null && (boolean) frmBorder.getTag();
+                    frmBorder.setBackgroundResource(isBackgroundVisible ? 0 : R.drawable.rounded_border_tv);
+                    imgClose.setVisibility(isBackgroundVisible ? View.GONE : View.VISIBLE);
+                    frmBorder.setTag(!isBackgroundVisible);
+                }
             }
 
             @Override
             public void onLongClick() {
             }
         });
+
+        if (!isBorderFunctionalityEnabled) {
+            imgClose.setVisibility(View.GONE);
+            frmBorder.setBackgroundResource(0);
+            frmBorder.setTag(false);
+        }
+
         emojiRootView.setOnTouchListener(multiTouchListener);
         addViewToParent(emojiRootView, ViewType.EMOJI);
     }
@@ -526,7 +553,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         for (int i = 0; i < parentView.getChildCount(); i++) {
             View childAt = parentView.getChildAt(i);
             FrameLayout frmBorder = childAt.findViewById(R.id.frmBorder);
-            if (frmBorder != null) {
+            if (frmBorder != null && isBorderFunctionalityEnabled) {
                 frmBorder.setBackgroundResource(0);
             }
             ImageView imgClose = childAt.findViewById(R.id.imgPhotoEditorClose);
@@ -834,6 +861,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         private Typeface emojiTypeface;
         //By Default pinch zoom on text is enabled
         private boolean isTextPinchZoomable = true;
+        private boolean isBorderFunctionalityEnabled = true;
 
         /**
          * Building a PhotoEditor which requires a Context and PhotoEditorView
@@ -884,6 +912,17 @@ public class PhotoEditor implements BrushViewChangeListener {
          */
         public Builder setPinchTextScalable(boolean isTextPinchZoomable) {
             this.isTextPinchZoomable = isTextPinchZoomable;
+            return this;
+        }
+
+        /**
+         * set false to disable the background border and close button
+         *
+         * @param isBorderFunctionalityEnabled flag to make pinch to zoom
+         * @return {@link Builder} instant to build {@link PhotoEditor}
+         */
+        public Builder setBorderFunctionalityEnabled(boolean isBorderFunctionalityEnabled) {
+            this.isBorderFunctionalityEnabled = isBorderFunctionalityEnabled;
             return this;
         }
 


### PR DESCRIPTION
- Added a boolean in builder to disable the boarder and the close button for views
- Added If-clause to prevent close and boarder view to be enabled when boarderFunctionality is turned of.

Turning of border functionality will prevent the user from removing the view by just clicking it and pressing close. This functionality is great for those who do not wish to have any border but simply use the delete view (separate PR) to remove views.