### PR TITLE
Add builder option to enable clicking though transparent pixels on images

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
@@ -129,12 +129,13 @@ class MultiTouchListener implements OnTouchListener {
         int x = (int) event.getRawX();
         int y = (int) event.getRawY();
 
-
         switch (action & event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
                 if (mShouldClickThroughTransparentPixels) {
                     if (isImageWithBitmapDrawable(view)) {
-                        return isOpaquePixelClicked(view, event);
+                        if(isTransparentPixelClicked(view, event)){
+                            return false;
+                        }
                     }
                 }
 
@@ -207,7 +208,7 @@ class MultiTouchListener implements OnTouchListener {
     /**
      * @return False if the click is on an fully transparent pixel, true otherwise.
      */
-    private boolean isOpaquePixelClicked(View view, MotionEvent event) {
+    private boolean isTransparentPixelClicked(View view, MotionEvent event) {
         ImageView image = view.findViewById(R.id.imgPhotoEditorImage);
         Bitmap bitmap = ((BitmapDrawable) image.getDrawable()).getBitmap();
 
@@ -238,10 +239,10 @@ class MultiTouchListener implements OnTouchListener {
         int pixelRGB = bitmap.getPixel(xX, yY);
 
         if (Color.alpha(pixelRGB) == 0 /* 100% transparent. No opacity */) {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     private void firePhotoEditorSDKListener(View view, boolean isStart) {

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
@@ -3,13 +3,16 @@ package ja.burhanrashid52.photoeditor;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Matrix;
+import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -42,14 +45,19 @@ class MultiTouchListener implements OnTouchListener {
     private OnGestureControl mOnGestureControl;
     private boolean mIsTextPinchZoomable;
     private boolean mShouldClickThroughTransparentPixels;
+    private int mVariableTransparentPixelsClickThroughRadius;
+    private int mTransparentPixelsClickThroughRadius;
     private OnPhotoEditorListener mOnPhotoEditorListener;
 
     MultiTouchListener(@Nullable View deleteView, RelativeLayout parentView,
                        ImageView photoEditImageView, boolean isTextPinchZoomable,
                        boolean shouldClickThroughTransparentPixels,
-                       OnPhotoEditorListener onPhotoEditorListener) {
+                       int transparentPixelsClickThroughRadius,
+                               OnPhotoEditorListener onPhotoEditorListener) {
         mIsTextPinchZoomable = isTextPinchZoomable;
         mShouldClickThroughTransparentPixels = shouldClickThroughTransparentPixels;
+        mVariableTransparentPixelsClickThroughRadius = transparentPixelsClickThroughRadius;
+        mTransparentPixelsClickThroughRadius = transparentPixelsClickThroughRadius;
         mScaleGestureDetector = new ScaleGestureDetector(new ScaleGestureListener());
         mGestureListener = new GestureDetector(new GestureListener());
         this.deleteView = deleteView;
@@ -133,7 +141,9 @@ class MultiTouchListener implements OnTouchListener {
             case MotionEvent.ACTION_DOWN:
                 if (mShouldClickThroughTransparentPixels) {
                     if (isImageWithBitmapDrawable(view)) {
-                        if(isTransparentPixelClicked(view, event)){
+
+                        //If user clicks on an transparent pixel we return but not absorbing the event
+                        if(!isOpaquePixelClicked(view, event)){
                             return false;
                         }
                     }
@@ -206,43 +216,151 @@ class MultiTouchListener implements OnTouchListener {
     }
 
     /**
-     * @return False if the click is on an fully transparent pixel, true otherwise.
+     * @return False if the click is on an fully transparent pixel (and if no opaque pixel is found inside the given radius), true otherwise.
      */
-    private boolean isTransparentPixelClicked(View view, MotionEvent event) {
+    private boolean isOpaquePixelClicked(View view, MotionEvent event) {
         ImageView image = view.findViewById(R.id.imgPhotoEditorImage);
+        FrameLayout border = view.findViewById(R.id.frmBorder);
         Bitmap bitmap = ((BitmapDrawable) image.getDrawable()).getBitmap();
 
-        float eventX = event.getX();
-        float eventY = event.getY();
-        float[] eventXY = new float[]{eventX, eventY};
+        int eventX = (int)event.getX();
+        int eventY = (int)event.getY();
 
+        Rect imageRect = new Rect();
+        image.getHitRect(imageRect);
+
+        //Check if you hit outside the image. If you hit the frame around the view we say that that you hit a transparent pixel.
+        if(!imageRect.contains(eventX, eventY)){
+            return false;
+        }
+
+        //Get rect of border
+        Rect borderRect = new Rect();
+        border.getHitRect(borderRect);
+
+        //Enable to enabled radius to scale together with scaling
+//        mVariableTransparentPixelsClickThroughRadius = (int)(mTransparentPixelsClickThroughRadius * view.getScaleX());
+
+        //The eventX and Y for the actual image (discluding the frame and any views around it)
+        int imageEventX = eventX - (imageRect.left + borderRect.left);
+        int imageEventY = eventY - (imageRect.top + borderRect.top);
+
+        float scaleFactorX = (float) bitmap.getWidth() / (float) image.getWidth();
+        float scaleFactorY = (float) bitmap.getHeight()/ (float)image.getHeight();
+
+        //To get the coordinates of the click relative to the bitmap we use an scaled image matrix
+        float[] imageEventXY = new float[]{imageEventX, imageEventY};
         Matrix invertMatrix = new Matrix();
         ((ImageView) image).getImageMatrix().invert(invertMatrix);
+        invertMatrix.setScale(scaleFactorX, scaleFactorY);
+        invertMatrix.mapPoints(imageEventXY);
 
-        invertMatrix.mapPoints(eventXY);
-        int xX = (int) eventXY[0];
-        int yY = (int) eventXY[1];
+        int bitmapX = (int) imageEventXY[0];
+        int bitmapY = (int) imageEventXY[1];
 
         //Limit x, y range within bitmap
-        if (xX < 0) {
-            xX = 0;
-        } else if (xX > bitmap.getWidth() - 1) {
-            xX = bitmap.getWidth() - 1;
+        if (bitmapX < 0) {
+            bitmapX = 0;
+        } else if (bitmapX > bitmap.getWidth() - 1) {
+            bitmapX = bitmap.getWidth() - 1;
         }
 
-        if (yY < 0) {
-            yY = 0;
-        } else if (yY > bitmap.getHeight() - 1) {
-            yY = bitmap.getHeight() - 1;
+        if (bitmapY < 0) {
+            bitmapY = 0;
+        } else if (bitmapY > bitmap.getHeight() - 1) {
+            bitmapY = bitmap.getHeight() - 1;
         }
 
-        int pixelRGB = bitmap.getPixel(xX, yY);
+        boolean[][] visitorMatrix = mVariableTransparentPixelsClickThroughRadius > 0 ? new boolean[(mVariableTransparentPixelsClickThroughRadius * 2) + 1][(mVariableTransparentPixelsClickThroughRadius * 2) + 1] : new boolean[1][1];
 
-        if (Color.alpha(pixelRGB) == 0 /* 100% transparent. No opacity */) {
-            return true;
+        return isPixelsInRadiusOpaque(visitorMatrix, bitmap, bitmapX, bitmapY, new Point(bitmapX, bitmapY));
+    }
+
+    /**
+     *
+     * @param bitmap
+     * @param x
+     * @param y
+     * @param currentPixel
+     * @return True if it finds any Opaque pixels on the given bitmap within the given radius of a given point. False otherwise.
+     */
+    private boolean isPixelsInRadiusOpaque(boolean[][] visitedMatrix, Bitmap bitmap, int x, int y, Point currentPixel){
+
+        try {
+            boolean inProximityOfClickedPixel = euclideanDistance(x, y, currentPixel) <= mVariableTransparentPixelsClickThroughRadius;
+
+            //Is pixel not inside the given radius
+            if(!inProximityOfClickedPixel){
+                return false;
+            }
+
+            if(hasPointBeenVisited(visitedMatrix, x, y, currentPixel)){
+                return false;
+            }
+
+            addPointToVisitorMatrix(visitedMatrix, x ,y , currentPixel);
+
+            int pixelRGB = bitmap.getPixel(currentPixel.x, currentPixel.y);
+
+            if(Color.alpha(pixelRGB) != 0){
+                return true;
+            } else {
+
+                Point topPoint = new Point(currentPixel.x, currentPixel.y - 1);
+                Point rightPoint = new Point(currentPixel.x + 1, currentPixel.y);
+                Point bottomPoint = new Point(currentPixel.x, currentPixel.y + 1);
+                Point leftPoint = new Point(currentPixel.x - 1, currentPixel.y);
+
+                // Checks the surrounding pixels, if inside radius we  check them for transparency.
+                // If all pixels are outside radius and this pixel is transparent we return true.
+                if(!(isPixelTransparent(bitmap, x, y, topPoint) && isPixelTransparent(bitmap, x, y, rightPoint)
+                   && isPixelTransparent(bitmap, x, y, bottomPoint) && isPixelTransparent(bitmap, x, y, leftPoint))){
+                    return true;
+                } else {
+                    //Check next pixel. This code could be optimized to run in circles instead
+                    return !(!isPixelsInRadiusOpaque(visitedMatrix, bitmap, x, y, topPoint) && !isPixelsInRadiusOpaque(visitedMatrix, bitmap, x, y, rightPoint) &&
+                            !isPixelsInRadiusOpaque(visitedMatrix, bitmap, x, y, bottomPoint) && !isPixelsInRadiusOpaque(visitedMatrix, bitmap, x, y, leftPoint));
+                }
+
+            }
+
+        } catch (IllegalArgumentException | IllegalStateException e){
+            Log.d("MultiTouchListener","Pixel not found in bitmap" + e);
         }
 
         return false;
+    }
+
+    private boolean isPixelTransparent(Bitmap bitmap, int x, int y, Point point){
+        try {
+            int pixelRGB = bitmap.getPixel(point.x, point.y);
+            return Color.alpha(pixelRGB) == 0; /* 0% transparent. Full opacity */
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            Log.d("MultiTouchListener", "Pixel not found in bitmap" + e);
+        }
+
+        //We return true if it fails to find pixel from bitmap as this could be outside the bitmap
+        return true;
+    }
+
+    private void addPointToVisitorMatrix(boolean[][] visitedMatrix, int x, int y, Point currentPixel){
+        int matrixX0 = x - mVariableTransparentPixelsClickThroughRadius;
+        int matrixY0 = y - mVariableTransparentPixelsClickThroughRadius;
+
+        visitedMatrix[currentPixel.x - matrixX0][currentPixel.y - matrixY0] = true;
+    }
+
+    private boolean hasPointBeenVisited(boolean[][] visitedMatrix, int x , int y, Point point){
+        int matrixX0 = x - mVariableTransparentPixelsClickThroughRadius;
+        int matrixY0 = y - mVariableTransparentPixelsClickThroughRadius;
+
+        return visitedMatrix[point.x - matrixX0][point.y - matrixY0];
+    }
+
+    private double euclideanDistance(int aX, int aY, Point pointB) {
+        double xDiff = aX - pointB.x;
+        double yDiff = aY - pointB.y;
+        return Math.sqrt(Math.pow(xDiff, 2) + Math.pow(yDiff, 2));
     }
 
     private void firePhotoEditorSDKListener(View view, boolean isStart) {

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -52,6 +52,7 @@ public class PhotoEditor implements BrushViewChangeListener {
     private OnPhotoEditorListener mOnPhotoEditorListener;
     private boolean isTextPinchZoomable;
     private boolean shouldClickThroughTransparentPixels;
+    private int transparentPixelsClickThroughRadius;
     private Typeface mDefaultTextTypeface;
     private Typeface mDefaultEmojiTypeface;
 
@@ -64,6 +65,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         this.brushDrawingView = builder.brushDrawingView;
         this.isTextPinchZoomable = builder.isTextPinchZoomable;
         this.shouldClickThroughTransparentPixels = builder.shouldClickThroughTransparentPixels;
+        this.transparentPixelsClickThroughRadius = builder.transparentPixelsClickThroughRadius;
         this.mDefaultTextTypeface = builder.textTypeface;
         this.mDefaultEmojiTypeface = builder.emojiTypeface;
         mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -275,6 +277,7 @@ public class PhotoEditor implements BrushViewChangeListener {
                 this.imageView,
                 isTextPinchZoomable,
                 shouldClickThroughTransparentPixels,
+                transparentPixelsClickThroughRadius,
                 mOnPhotoEditorListener);
 
         //multiTouchListener.setOnMultiTouchListener(this);
@@ -838,6 +841,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         //By Default pinch zoom on text is enabled
         private boolean isTextPinchZoomable = true;
         private boolean shouldClickThroughTransparentPixels = false;
+        private int transparentPixelsClickThroughRadius = 0;
 
         /**
          * Building a PhotoEditor which requires a Context and PhotoEditorView
@@ -894,11 +898,29 @@ public class PhotoEditor implements BrushViewChangeListener {
         /**
          * set true to disable clicking on the fully transparent parts of an image
          *
-         * @param shouldClickThroughTransparentPixels flag to make pinch to zoom
+         * @param shouldClickThroughTransparentPixels flag to enable clickThrough on transparent pixels
          * @return {@link Builder} instant to build {@link PhotoEditor}
          */
         public Builder setClickThroughTransparentPixels(boolean shouldClickThroughTransparentPixels) {
             this.shouldClickThroughTransparentPixels = shouldClickThroughTransparentPixels;
+            return this;
+        }
+
+        /**
+         * set the radius for witch the isTransparentPixelClicked method checks nearby pixels for transparency
+         *
+         * Radius is defined in Pixels around click location
+         *
+         * This is used to get a larger hit radius but still keep clickThrough on transparent pixels with only transparent pixels nearby
+         * (e.g. if struggling to target some images that has a lot of transparency inside them then increasing the radius will help)
+         *
+         * NB! Radius has to be larger than zero
+         *
+         * @param transparentPixelsClickThroughRadius value for click through radius
+         * @return {@link Builder} instant to build {@link PhotoEditor}
+         */
+        public Builder setTransparentPixelClickThroughRadius(int transparentPixelsClickThroughRadius) {
+            this.transparentPixelsClickThroughRadius = transparentPixelsClickThroughRadius >= 0 ? transparentPixelsClickThroughRadius : 0;
             return this;
         }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -51,6 +51,7 @@ public class PhotoEditor implements BrushViewChangeListener {
     private List<View> redoViews;
     private OnPhotoEditorListener mOnPhotoEditorListener;
     private boolean isTextPinchZoomable;
+    private boolean shouldClickThroughTransparentPixels;
     private Typeface mDefaultTextTypeface;
     private Typeface mDefaultEmojiTypeface;
 
@@ -62,6 +63,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         this.deleteView = builder.deleteView;
         this.brushDrawingView = builder.brushDrawingView;
         this.isTextPinchZoomable = builder.isTextPinchZoomable;
+        this.shouldClickThroughTransparentPixels = builder.shouldClickThroughTransparentPixels;
         this.mDefaultTextTypeface = builder.textTypeface;
         this.mDefaultEmojiTypeface = builder.emojiTypeface;
         mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -272,6 +274,7 @@ public class PhotoEditor implements BrushViewChangeListener {
                 parentView,
                 this.imageView,
                 isTextPinchZoomable,
+                shouldClickThroughTransparentPixels,
                 mOnPhotoEditorListener);
 
         //multiTouchListener.setOnMultiTouchListener(this);
@@ -834,6 +837,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         private Typeface emojiTypeface;
         //By Default pinch zoom on text is enabled
         private boolean isTextPinchZoomable = true;
+        private boolean shouldClickThroughTransparentPixels = false;
 
         /**
          * Building a PhotoEditor which requires a Context and PhotoEditorView
@@ -884,6 +888,17 @@ public class PhotoEditor implements BrushViewChangeListener {
          */
         public Builder setPinchTextScalable(boolean isTextPinchZoomable) {
             this.isTextPinchZoomable = isTextPinchZoomable;
+            return this;
+        }
+
+        /**
+         * set true to disable clicking on the fully transparent parts of an image
+         *
+         * @param shouldClickThroughTransparentPixels flag to make pinch to zoom
+         * @return {@link Builder} instant to build {@link PhotoEditor}
+         */
+        public Builder setClickThroughTransparentPixels(boolean shouldClickThroughTransparentPixels) {
+            this.shouldClickThroughTransparentPixels = shouldClickThroughTransparentPixels;
             return this;
         }
 


### PR DESCRIPTION
- Added an option in PhotoEditor to enable clicking through transparent pixels.
- Added logic in MultiTouchListener to check event click location for transparent pixel and return false if pixel is transparent (e.g. click goes through to next layer)

This functionality enables the possibility of moving images that are below other images as long as they are visible. It makes it a lot easier to select and move an image among a group of other images (where you before had to basically move the top image away to be able to select the image below it).

The feature currently only works on images, but it could be applied to text, emoji, ect with future updates.