### PR TITLE
Do not clear views after successfully saving the image 

### DIFF
--- a/app/src/main/java/com/burhanrashid52/imageeditor/EditImageActivity.java
+++ b/app/src/main/java/com/burhanrashid52/imageeditor/EditImageActivity.java
@@ -220,6 +220,7 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
                     public void onSuccess(@NonNull String imagePath) {
                         hideLoading();
                         showSnackbar("Image Saved Successfully");
+                        mPhotoEditor.clearAllViews();
                         mPhotoEditorView.getSource().setImageURI(Uri.fromFile(new File(imagePath)));
                     }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -622,7 +622,6 @@ public class PhotoEditor implements BrushViewChangeListener {
             protected void onPostExecute(Exception e) {
                 super.onPostExecute(e);
                 if (e == null) {
-                    clearAllViews();
                     onSaveListener.onSuccess(imagePath);
                 } else {
                     onSaveListener.onFailure(e);
@@ -683,7 +682,6 @@ public class PhotoEditor implements BrushViewChangeListener {
                     protected void onPostExecute(Exception e) {
                         super.onPostExecute(e);
                         if (e == null) {
-                            clearAllViews();
                             onSaveListener.onSuccess(imagePath);
                         } else {
                             onSaveListener.onFailure(e);
@@ -733,7 +731,6 @@ public class PhotoEditor implements BrushViewChangeListener {
                     protected void onPostExecute(Bitmap bitmap) {
                         super.onPostExecute(bitmap);
                         if (bitmap != null) {
-                            clearAllViews();
                             onSaveBitmap.onBitmapReady(bitmap);
                         } else {
                             onSaveBitmap.onFailure(new Exception("Failed to load the bitmap"));


### PR DESCRIPTION
Saving the image should not assume that the client will replace the current state with the static image that is generated.
If that is what the client of the library expects, that can be done by the client in the result handler.
Another alternative would be to create another method called saveImageAndClearViews, but it is better that functions do only one thing that can be inferred from the name of the method.