### PR TITLE
Changed visibility of constructor from private to protected

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -55,7 +55,7 @@ public class PhotoEditor implements BrushViewChangeListener {
     private Typeface mDefaultEmojiTypeface;
 
 
-    private PhotoEditor(Builder builder) {
+    protected PhotoEditor(Builder builder) {
         this.context = builder.context;
         this.parentView = builder.parentView;
         this.imageView = builder.imageView;


### PR DESCRIPTION
By having a private constructor it is not possible to extend the class.

The idea behind making the constructor protected is to allow subclasses to extend PhotoEditor.
This is convenient for custom projects that need to specify a different logic without having to modify the source code of the PhotoEditor class.