### PR TITLE
Fixed brush drawing issue

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -653,6 +653,7 @@ public class PhotoEditor implements BrushViewChangeListener {
                     protected void onPreExecute() {
                         super.onPreExecute();
                         clearHelperBox();
+                        brushDrawingView.invalidate();
                         parentView.setDrawingCacheEnabled(false);
                     }
 
@@ -732,6 +733,7 @@ public class PhotoEditor implements BrushViewChangeListener {
                     protected void onPreExecute() {
                         super.onPreExecute();
                         clearHelperBox();
+                        brushDrawingView.invalidate();
                         parentView.setDrawingCacheEnabled(false);
                     }
 


### PR DESCRIPTION
… root cause the brushDrawingView should call onDraw(Canvas canvas) function for make sure the brush view draw correctly before get the image from parent view. And it fixed "https://github.com/burhanrashid52/PhotoEditor/issues/57" issue as well 