### PR TITLE
Pe 226 fix acces to external storage problem android10

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name="com.burhanrashid52.photoeditor.EditImageActivity"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/burhanrashid52/photoeditor/EditImageActivity.java
+++ b/app/src/main/java/com/burhanrashid52/photoeditor/EditImageActivity.java
@@ -2,6 +2,7 @@ package com.burhanrashid52.photoeditor;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -263,9 +264,8 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
     private void saveImage() {
         if (requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             showLoading("Saving...");
-            File file = new File(Environment.getExternalStorageDirectory()
-                    + File.separator + ""
-                    + System.currentTimeMillis() + ".png");
+            final File file = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
+                System.currentTimeMillis() + ".png");
             try {
                 file.createNewFile();
 
@@ -281,6 +281,7 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
                         showSnackbar("Image Saved Successfully");
                         mSaveImageUri = Uri.fromFile(new File(imagePath));
                         mPhotoEditorView.getSource().setImageURI(mSaveImageUri);
+                        galleryAddPic(EditImageActivity.this, file.getAbsolutePath());
                     }
 
                     @Override
@@ -295,6 +296,14 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
                 showSnackbar(e.getMessage());
             }
         }
+    }
+    //added file to gallery
+    private static void galleryAddPic(Context context, String imagePath) {
+        Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+        File f = new File(imagePath);
+        Uri contentUri = Uri.fromFile(f);
+        mediaScanIntent.setData(contentUri);
+        context.sendBroadcast(mediaScanIntent);
     }
 
     @Override


### PR DESCRIPTION
**What does this PR do?**
- [x] Adds `android:requestLegacyExternalStorage="true"` in `app:manifest` file, to allow external storage in Android10
- [x] Adds `galleryAddPic()` : to add edited photos to the `Picture Directory`

**Link to Issue**
[#226](https://github.com/burhanrashid52/PhotoEditor/issues/226)