### PR TITLE
#57 Fixed brush view drawing cache not being invalidated resulting in…

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -654,6 +654,7 @@ public class PhotoEditor implements BrushViewChangeListener {
                         super.onPreExecute();
                         clearHelperBox();
                         parentView.setDrawingCacheEnabled(false);
+                        brushDrawingView.destroyDrawingCache();
                     }
 
                     @SuppressLint("MissingPermission")
@@ -733,6 +734,7 @@ public class PhotoEditor implements BrushViewChangeListener {
                         super.onPreExecute();
                         clearHelperBox();
                         parentView.setDrawingCacheEnabled(false);
+                        brushDrawingView.destroyDrawingCache();
                     }
 
                     @Override


### PR DESCRIPTION
… inconsistent saved images.

I was experiencing the same issue where after saving an image with only a sticker, the brush lines added later would not be saved. 

After some debugging I noticed that this happens whenever the image was saved without using the brush at all - so saving the image without anything drawn on the brush view canvas. 

After some more debugging I noticed that the bitmap we get from the getDrawingCache call in the saveAsFile and saveAsBitmap methods is also missing the brush strokes. This led me to believe that this has something to do with the brush view drawing cache and indeed it had. It turned out that the brush view drawing cache was not invalidated when the setDrawingCacheEnabled(false) method was called.

I figured if I manually destroy the drawing cache, it would be recreated next time the parent cache is generated and that seemed to be the case. After adding the lines included in this PR, the issue was fixed.

I have tested with and without the fix on the demo app (included in the project) and the brush strokes were saved in the last step.

Since this is a very old issue I doubt it will be of use to @ervinod, but it will save trouble for future users of the (very cool) library. So please, @burhanrashid52 if you have a bit of spare time, check if this indeed fixes the issue and maybe create a patch release? :)