### PR TITLE
Replace deprecated `getDrawingCache` to capturing method.

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Typeface;
 import android.os.AsyncTask;
 import androidx.annotation.ColorInt;
@@ -653,7 +654,6 @@ public class PhotoEditor implements BrushViewChangeListener {
                     protected void onPreExecute() {
                         super.onPreExecute();
                         clearHelperBox();
-                        parentView.setDrawingCacheEnabled(false);
                         brushDrawingView.destroyDrawingCache();
                     }
 
@@ -665,11 +665,10 @@ public class PhotoEditor implements BrushViewChangeListener {
                         try {
                             FileOutputStream out = new FileOutputStream(file, false);
                             if (parentView != null) {
-                                parentView.setDrawingCacheEnabled(true);
-                                Bitmap drawingCache = saveSettings.isTransparencyEnabled()
-                                        ? BitmapUtil.removeTransparency(parentView.getDrawingCache())
-                                        : parentView.getDrawingCache();
-                                drawingCache.compress(saveSettings.getCompressFormat(), saveSettings.getCompressQuality(), out);
+                                Bitmap capturedBitmap = saveSettings.isTransparencyEnabled()
+                                        ? BitmapUtil.removeTransparency(captureView(parentView))
+                                        : captureView(parentView);
+                                capturedBitmap.compress(saveSettings.getCompressFormat(), saveSettings.getCompressQuality(), out);
                             }
                             out.flush();
                             out.close();
@@ -733,17 +732,15 @@ public class PhotoEditor implements BrushViewChangeListener {
                     protected void onPreExecute() {
                         super.onPreExecute();
                         clearHelperBox();
-                        parentView.setDrawingCacheEnabled(false);
                         brushDrawingView.destroyDrawingCache();
                     }
 
                     @Override
                     protected Bitmap doInBackground(String... strings) {
                         if (parentView != null) {
-                            parentView.setDrawingCacheEnabled(true);
                             return saveSettings.isTransparencyEnabled() ?
-                                    BitmapUtil.removeTransparency(parentView.getDrawingCache())
-                                    : parentView.getDrawingCache();
+                                    BitmapUtil.removeTransparency(captureView(parentView))
+                                    : captureView(parentView);
                         } else {
                             return null;
                         }
@@ -779,6 +776,17 @@ public class PhotoEditor implements BrushViewChangeListener {
             returnedEmoji = "";
         }
         return returnedEmoji;
+    }
+
+    private Bitmap captureView(View view) {
+        Bitmap bitmap = Bitmap.createBitmap(
+                view.getWidth(),
+                view.getHeight(),
+                Bitmap.Config.ARGB_8888
+        );
+        Canvas canvas = new Canvas(bitmap);
+        view.draw(canvas);
+        return bitmap;
     }
 
     /**


### PR DESCRIPTION
## Summary
`getDrawingCache` is [deprecated](https://developer.android.com/reference/android/view/View#getDrawingCache()) and it occurs error #284.

## How should we fix it?
[Google suggests to use PixelCopy](https://developer.android.com/reference/android/view/View#getDrawingCache()) instead of getDrawingCache. But it requires window instance. It is difficult to get a window instance without the dependency of an activity or fragment. 

So, as the next best thing, I drew a bitmap of the view on the canvas.
