### PR TITLE
Fix isTextPinchScalable flag so it does not disable pinch-scaling for emoji and sticker

### DIFF
--- a/app/src/androidTest/java/com/burhanrashid52/photoediting/EditImageActivityTest.java
+++ b/app/src/androidTest/java/com/burhanrashid52/photoediting/EditImageActivityTest.java
@@ -1,8 +1,10 @@
 package com.burhanrashid52.photoediting;
 
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import androidx.test.espresso.NoMatchingViewException;
@@ -26,6 +28,7 @@ import ja.burhanrashid52.photoeditor.PhotoEditor;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -33,7 +36,9 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 
@@ -129,6 +134,109 @@ public class EditImageActivityTest {
         Thread.sleep(2000);
         onView(withId(R.id.imgShare)).perform(click());
         //onView(withText(R.string.msg_save_image_to_share)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void checkIfPinchTextScalableFlagWorks_False() throws InterruptedException {
+
+        // Use an intent to tell EditImageActivity to set the PhotoEditor "pinchTextScalableFlag" to "false"
+        final Intent intent = new Intent();
+        intent.putExtra(EditImageActivity.PINCH_TEXT_SCALABLE_INTENT_KEY, false);
+        mActivityRule.launchActivity(intent);
+
+        // Open the emoji menu (delay to give time to load lower menu)
+        Thread.sleep(2000);
+        onView(withText(R.string.label_emoji)).perform(click());
+
+        // Add an emoji from the menu (delay to give time for the RecyclerView to open)
+        Thread.sleep(2000);
+        onView(withId(R.id.rvEmoji))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(1, click()));
+
+        // Select the emoji (delay to give time for the RecyclerView to close)
+        Thread.sleep(1000);
+        onView(withId((R.id.frmBorder))).perform(click());
+
+        // Capture the scale of the emoji
+        ViewGroup emojiFrameParentView = (ViewGroup) mActivityRule.getActivity().findViewById(R.id.frmBorder).getParent();
+        final float emojiScaleXBeforePinching = emojiFrameParentView.getScaleX();
+        final float emojiScaleYBeforePinching = emojiFrameParentView.getScaleY();
+
+        // Scale the emoji up by pinching
+        onView(withId((R.id.frmBorder))).perform(PinchTestHelper.pinchOut());
+
+        // Check if the emoji scaled up after pinching.
+        emojiFrameParentView = (ViewGroup) mActivityRule.getActivity().findViewById(R.id.frmBorder).getParent();
+        assertNotEquals(emojiScaleXBeforePinching, emojiFrameParentView.getScaleX());
+        assertNotEquals(emojiScaleYBeforePinching, emojiFrameParentView.getScaleY());
+
+        // Remove the emoji from the screen.
+        onView(withId(R.id.imgPhotoEditorClose)).perform(click());
+
+        // Add a text to the image.
+        onView(withText(R.string.label_text)).perform(click());
+        onView(withId(R.id.add_text_edit_text)).perform(click());
+        onView(withId(R.id.add_text_edit_text)).perform(typeText("Test Text"));
+
+        // Select the text (delay to give time for the text imput screen to close)
+        Thread.sleep(2000);
+        onView(withId(R.id.add_text_done_tv)).perform(click());
+
+        // Select the text box
+        Matcher<View> testTextBox = withId(R.id.tvPhotoEditorText);
+        onView(testTextBox).perform(click());
+
+        // Capture the current scale of the text box
+        ViewGroup textFrameParentView = (ViewGroup) mActivityRule.getActivity().findViewById(R.id.frmBorder).getParent();
+        final float textScaleXBeforeScaling = textFrameParentView.getScaleX();
+        final float textScaleYBeforeScaling = textFrameParentView.getScaleY();
+
+        // Attempt to scale the text box by pinching
+        onView(testTextBox).perform(PinchTestHelper.pinchOut());
+
+        // Validate that the text box did not scale by pinching.
+        textFrameParentView = (ViewGroup) mActivityRule.getActivity().findViewById(R.id.frmBorder).getParent();
+        assertEquals(textScaleXBeforeScaling, textFrameParentView.getScaleX(), 0.01);
+        assertEquals(textScaleYBeforeScaling, textFrameParentView.getScaleY(), 0.01);
+    }
+
+    @Test
+    public void checkIfPinchTextScalableFlagWorks_True() throws InterruptedException {
+
+        // Use an intent to tell EditImageActivity to set the PhotoEditor "pinchTextScalableFlag" to "false"
+        final Intent intent = new Intent();
+        intent.putExtra(EditImageActivity.PINCH_TEXT_SCALABLE_INTENT_KEY, true);
+        mActivityRule.launchActivity(intent);
+
+        // Open the emoji menu (delay to give time to load lower menu)
+        Thread.sleep(2000);
+        onView(withText(R.string.label_text)).perform(click());
+        onView(withId(R.id.add_text_edit_text)).perform(click());
+
+        // Type the text (delay to allow keyboard to load)
+        Thread.sleep(2000);
+        onView(withId(R.id.add_text_edit_text)).perform(typeText("Test Text"));
+
+        // Select the text (delay to give time for the text imput screen to close)
+        Thread.sleep(2000);
+        onView(withId(R.id.add_text_done_tv)).perform(click());
+
+        // Select the text box
+        Matcher<View> testTextBox = withId(R.id.tvPhotoEditorText);
+        onView(testTextBox).perform(click());
+
+        // Capture the current scale of the text box
+        ViewGroup textFrameParentView = (ViewGroup) mActivityRule.getActivity().findViewById(R.id.frmBorder).getParent();
+        final float textScaleXBeforeScaling = textFrameParentView.getScaleX();
+        final float textScaleYBeforeScaling = textFrameParentView.getScaleY();
+
+        // Attempt to scale the text box by pinching
+        onView(testTextBox).perform(PinchTestHelper.pinchOut());
+
+        // Validate that the text box did not scale by pinching.
+        textFrameParentView = (ViewGroup) mActivityRule.getActivity().findViewById(R.id.frmBorder).getParent();
+        assertNotEquals(textScaleXBeforeScaling, textFrameParentView.getScaleX());
+        assertNotEquals(textScaleYBeforeScaling, textFrameParentView.getScaleY());
     }
 
     @Test

--- a/app/src/androidTest/java/com/burhanrashid52/photoediting/PinchTestHelper.java
+++ b/app/src/androidTest/java/com/burhanrashid52/photoediting/PinchTestHelper.java
@@ -40,7 +40,7 @@ public class PinchTestHelper {
                 final int startDelta = 10;
 
                 // How far from the center point each finger should end
-                // (note: Be sure to have this large enough so that the gesture is recognized, in practice this appears to be 60)
+                // (note: Be sure to have this large enough so that the gesture is recognized)
                 final int endDelta = 20;
 
                 Point startPoint1 = new Point(middlePosition.x - startDelta, middlePosition.y);

--- a/app/src/androidTest/java/com/burhanrashid52/photoediting/PinchTestHelper.java
+++ b/app/src/androidTest/java/com/burhanrashid52/photoediting/PinchTestHelper.java
@@ -1,0 +1,228 @@
+package com.burhanrashid52.photoediting;
+
+import android.graphics.Point;
+import android.os.SystemClock;
+import android.view.MotionEvent;
+import android.view.View;
+
+import org.hamcrest.Matcher;
+
+import androidx.annotation.NonNull;
+import androidx.test.espresso.InjectEventSecurityException;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.action.MotionEvents;
+import androidx.test.espresso.matcher.ViewMatchers;
+
+/**
+ * Helper used to test "pinch" actions.
+ * Taken from https://stackoverflow.com/a/46443628
+ */
+public class PinchTestHelper {
+    public static ViewAction pinchOut() {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return ViewMatchers.isEnabled();
+            }
+
+            @Override
+            public String getDescription() {
+                return "Pinch out";
+            }
+
+            @Override
+            public void perform(UiController uiController, View view) {
+                Point middlePosition = getCenterPoint(view);
+
+                // How far from the center point each finger should start
+                // (note: If you make this 0, where the two fingers are on top of one another, the view may disappear)
+                final int startDelta = 10;
+
+                // How far from the center point each finger should end
+                // (note: Be sure to have this large enough so that the gesture is recognized, in practice this appears to be 60)
+                final int endDelta = 20;
+
+                Point startPoint1 = new Point(middlePosition.x - startDelta, middlePosition.y);
+                Point startPoint2 = new Point(middlePosition.x + startDelta, middlePosition.y);
+                Point endPoint1 = new Point(middlePosition.x - endDelta, middlePosition.y);
+                Point endPoint2 = new Point(middlePosition.x + endDelta, middlePosition.y);
+
+                performPinch(uiController, startPoint1, startPoint2, endPoint1, endPoint2);
+            }
+        };
+    }
+
+    public static ViewAction pinchIn() {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return ViewMatchers.isEnabled();
+            }
+
+            @Override
+            public String getDescription() {
+                return "Pinch in";
+            }
+
+            @Override
+            public void perform(UiController uiController, View view) {
+                Point middlePosition = getCenterPoint(view);
+
+                final int startDelta = 500; // How far from the center point each finger should start (note: Be sure to have this large enough so that the gesture is recognized!)
+                final int endDelta = 0; // How far from the center point each finger should end
+
+                Point startPoint1 = new Point(middlePosition.x - startDelta, middlePosition.y);
+                Point startPoint2 = new Point(middlePosition.x + startDelta, middlePosition.y);
+                Point endPoint1 = new Point(middlePosition.x - endDelta, middlePosition.y);
+                Point endPoint2 = new Point(middlePosition.x + endDelta, middlePosition.y);
+
+                performPinch(uiController, startPoint1, startPoint2, endPoint1, endPoint2);
+            }
+        };
+    }
+
+    @NonNull
+    private static Point getCenterPoint(View view) {
+        int[] locationOnScreen = new int[2];
+        view.getLocationOnScreen(locationOnScreen);
+        float viewHeight = view.getHeight() * view.getScaleY();
+        float viewWidth = view.getWidth() * view.getScaleX();
+        return new Point(
+                (int) (locationOnScreen[0] + viewWidth / 2),
+                (int) (locationOnScreen[1] + viewHeight / 2));
+    }
+
+    private static void performPinch(UiController uiController, Point startPoint1, Point startPoint2, Point endPoint1, Point endPoint2) {
+        final int duration = 500;
+        final long eventMinInterval = 10;
+        final long startTime = SystemClock.uptimeMillis();
+        long eventTime = startTime;
+        MotionEvent event;
+        float eventX1, eventY1, eventX2, eventY2;
+
+        eventX1 = startPoint1.x;
+        eventY1 = startPoint1.y;
+        eventX2 = startPoint2.x;
+        eventY2 = startPoint2.y;
+
+        // Specify the property for the two touch points
+        MotionEvent.PointerProperties[] properties = new MotionEvent.PointerProperties[2];
+        MotionEvent.PointerProperties pp1 = new MotionEvent.PointerProperties();
+        pp1.id = 0;
+        pp1.toolType = MotionEvent.TOOL_TYPE_FINGER;
+        MotionEvent.PointerProperties pp2 = new MotionEvent.PointerProperties();
+        pp2.id = 1;
+        pp2.toolType = MotionEvent.TOOL_TYPE_FINGER;
+
+        properties[0] = pp1;
+        properties[1] = pp2;
+
+        // Specify the coordinations of the two touch points
+        // NOTE: you MUST set the pressure and size value, or it doesn't work
+        MotionEvent.PointerCoords[] pointerCoords = new MotionEvent.PointerCoords[2];
+        MotionEvent.PointerCoords pc1 = new MotionEvent.PointerCoords();
+        pc1.x = eventX1;
+        pc1.y = eventY1;
+        pc1.pressure = 1;
+        pc1.size = 1;
+        MotionEvent.PointerCoords pc2 = new MotionEvent.PointerCoords();
+        pc2.x = eventX2;
+        pc2.y = eventY2;
+        pc2.pressure = 1;
+        pc2.size = 1;
+        pointerCoords[0] = pc1;
+        pointerCoords[1] = pc2;
+
+        /*
+         * Events sequence of zoom gesture:
+         *
+         * 1. Send ACTION_DOWN event of one start point
+         * 2. Send ACTION_POINTER_DOWN of two start points
+         * 3. Send ACTION_MOVE of two middle points
+         * 4. Repeat step 3 with updated middle points (x,y), until reach the end points
+         * 5. Send ACTION_POINTER_UP of two end points
+         * 6. Send ACTION_UP of one end point
+         */
+
+        try {
+            // Step 1
+            event = MotionEvent.obtain(startTime, eventTime,
+                    MotionEvent.ACTION_DOWN, 1, properties,
+                    pointerCoords, 0, 0, 1, 1, 0, 0, 0, 0);
+            injectMotionEventToUiController(uiController, event);
+
+            // Step 2
+            event = MotionEvent.obtain(startTime, eventTime,
+                    MotionEvent.ACTION_POINTER_DOWN + (pp2.id << MotionEvent.ACTION_POINTER_INDEX_SHIFT), 2,
+                    properties, pointerCoords, 0, 0, 1, 1, 0, 0, 0, 0);
+            injectMotionEventToUiController(uiController, event);
+
+            // Step 3, 4
+            long moveEventNumber = duration / eventMinInterval;
+
+            float stepX1, stepY1, stepX2, stepY2;
+
+            stepX1 = (endPoint1.x - startPoint1.x) / (float)moveEventNumber;
+            stepY1 = (endPoint1.y - startPoint1.y) / (float)moveEventNumber;
+            stepX2 = (endPoint2.x - startPoint2.x) / (float)moveEventNumber;
+            stepY2 = (endPoint2.y - startPoint2.y) / (float)moveEventNumber;
+
+            for (int i = 0; i < moveEventNumber; i++) {
+                // Update the move events
+                eventTime += eventMinInterval;
+                eventX1 += stepX1;
+                eventY1 += stepY1;
+                eventX2 += stepX2;
+                eventY2 += stepY2;
+
+                pc1.x = eventX1;
+                pc1.y = eventY1;
+                pc2.x = eventX2;
+                pc2.y = eventY2;
+
+                pointerCoords[0] = pc1;
+                pointerCoords[1] = pc2;
+
+                event = MotionEvent.obtain(startTime, eventTime,
+                        MotionEvent.ACTION_MOVE, 2, properties,
+                        pointerCoords, 0, 0, 1, 1, 0, 0, 0, 0);
+                injectMotionEventToUiController(uiController, event);
+            }
+
+            // Step 5
+            pc1.x = endPoint1.x;
+            pc1.y = endPoint1.y;
+            pc2.x = endPoint2.x;
+            pc2.y = endPoint2.y;
+            pointerCoords[0] = pc1;
+            pointerCoords[1] = pc2;
+
+            eventTime += eventMinInterval;
+            event = MotionEvent.obtain(startTime, eventTime,
+                    MotionEvent.ACTION_POINTER_UP + (pp2.id << MotionEvent.ACTION_POINTER_INDEX_SHIFT), 2, properties,
+                    pointerCoords, 0, 0, 1, 1, 0, 0, 0, 0);
+            injectMotionEventToUiController(uiController, event);
+
+            // Step 6
+            eventTime += eventMinInterval;
+            event = MotionEvent.obtain(startTime, eventTime,
+                    MotionEvent.ACTION_UP, 1, properties,
+                    pointerCoords, 0, 0, 1, 1, 0, 0, 0, 0);
+            injectMotionEventToUiController(uiController, event);
+        } catch (InjectEventSecurityException e) {
+            throw new RuntimeException("Could not perform pinch", e);
+        }
+    }
+
+    /**
+     * Safely call uiController.injectMotionEvent(event): Detect any error and "convert" it to an
+     * IllegalStateException
+     */
+    private static void injectMotionEventToUiController(UiController uiController, MotionEvent event) throws InjectEventSecurityException {
+        boolean injectEventSucceeded = uiController.injectMotionEvent(event);
+        if (!injectEventSucceeded) {
+            throw new IllegalStateException("Error performing event " + event);
+        }
+    }
+}

--- a/app/src/main/java/com/burhanrashid52/photoediting/EditImageActivity.java
+++ b/app/src/main/java/com/burhanrashid52/photoediting/EditImageActivity.java
@@ -59,6 +59,8 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
     private static final int CAMERA_REQUEST = 52;
     private static final int PICK_REQUEST = 53;
     public static final String ACTION_NEXTGEN_EDIT = "action_nextgen_edit";
+    public static final String PINCH_TEXT_SCALABLE_INTENT_KEY = "PINCH_TEXT_SCALABLE";
+
     PhotoEditor mPhotoEditor;
     private PhotoEditorView mPhotoEditorView;
     private PropertiesBSFragment mPropertiesBSFragment;
@@ -106,12 +108,14 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
         mRvFilters.setLayoutManager(llmFilters);
         mRvFilters.setAdapter(mFilterViewAdapter);
 
+        // NOTE(lucianocheng): Used to set integration testing parameters to PhotoEditor
+        boolean pinchTextScalable = getIntent().getBooleanExtra(PINCH_TEXT_SCALABLE_INTENT_KEY, true);
 
         //Typeface mTextRobotoTf = ResourcesCompat.getFont(this, R.font.roboto_medium);
         //Typeface mEmojiTypeFace = Typeface.createFromAsset(getAssets(), "emojione-android.ttf");
 
         mPhotoEditor = new PhotoEditor.Builder(this, mPhotoEditorView)
-                .setPinchTextScalable(true) // set flag to make text scalable when pinch
+                .setPinchTextScalable(pinchTextScalable) // set flag to make text scalable when pinch
                 //.setDefaultTextTypeface(mTextRobotoTf)
                 //.setDefaultEmojiTypeface(mEmojiTypeFace)
                 .build(); // build photo editor sdk
@@ -127,8 +131,10 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
     private void handleIntentImage(ImageView source) {
         Intent intent = getIntent();
         if (intent != null) {
-            if (intent.getAction().equals(Intent.ACTION_EDIT) ||
-                    intent.getAction().equals(ACTION_NEXTGEN_EDIT)) {
+            // NOTE(lucianocheng): Using "yoda conditions" here to guard against
+            //                     a null Action in the Intent.
+            if (Intent.ACTION_EDIT.equals(intent.getAction()) ||
+                    ACTION_NEXTGEN_EDIT.equals(intent.getAction())) {
                 try {
                     Uri uri = intent.getData();
                     Bitmap bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), uri);

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.java
@@ -36,7 +36,7 @@ class MultiTouchListener implements OnTouchListener {
 
     private OnMultiTouchListener onMultiTouchListener;
     private OnGestureControl mOnGestureControl;
-    private boolean mIsTextPinchZoomable;
+    private boolean mIsPinchScalable;
     private OnPhotoEditorListener mOnPhotoEditorListener;
 
     private PhotoEditorViewState viewState;
@@ -44,11 +44,11 @@ class MultiTouchListener implements OnTouchListener {
     MultiTouchListener(@Nullable View deleteView,
                        RelativeLayout parentView,
                        ImageView photoEditImageView,
-                       boolean isTextPinchZoomable,
+                       boolean isPinchScalable,
                        OnPhotoEditorListener onPhotoEditorListener,
                        PhotoEditorViewState viewState
     ) {
-        mIsTextPinchZoomable = isTextPinchZoomable;
+        mIsPinchScalable = isPinchScalable;
         mScaleGestureDetector = new ScaleGestureDetector(new ScaleGestureListener());
         mGestureListener = new GestureDetector(new GestureListener());
         this.deleteView = deleteView;
@@ -217,7 +217,7 @@ class MultiTouchListener implements OnTouchListener {
             mPivotX = detector.getFocusX();
             mPivotY = detector.getFocusY();
             mPrevSpanVector.set(detector.getCurrentSpanVector());
-            return mIsTextPinchZoomable;
+            return mIsPinchScalable;
         }
 
         @Override
@@ -232,7 +232,7 @@ class MultiTouchListener implements OnTouchListener {
             info.minimumScale = minimumScale;
             info.maximumScale = maximumScale;
             move(view, info);
-            return !mIsTextPinchZoomable;
+            return !mIsPinchScalable;
         }
     }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.java
@@ -52,7 +52,7 @@ public class PhotoEditor implements BrushViewChangeListener {
     private View deleteView;
     private BrushDrawingView brushDrawingView;
     private OnPhotoEditorListener mOnPhotoEditorListener;
-    private boolean isTextPinchZoomable;
+    private boolean isTextPinchScalable;
     private Typeface mDefaultTextTypeface;
     private Typeface mDefaultEmojiTypeface;
 
@@ -63,7 +63,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         this.imageView = builder.imageView;
         this.deleteView = builder.deleteView;
         this.brushDrawingView = builder.brushDrawingView;
-        this.isTextPinchZoomable = builder.isTextPinchZoomable;
+        this.isTextPinchScalable = builder.isTextPinchScalable;
         this.mDefaultTextTypeface = builder.textTypeface;
         this.mDefaultEmojiTypeface = builder.emojiTypeface;
         this.viewState = new PhotoEditorViewState();
@@ -105,7 +105,7 @@ public class PhotoEditor implements BrushViewChangeListener {
 
         imageView.setImageBitmap(desiredImage);
 
-        MultiTouchListener multiTouchListener = getMultiTouchListener();
+        MultiTouchListener multiTouchListener = getMultiTouchListener(true);
         multiTouchListener.setOnGestureControl(new MultiTouchListener.OnGestureControl() {
             @Override
             public void onClick() {
@@ -179,7 +179,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         if (styleBuilder != null)
             styleBuilder.applyStyle(textInputTv);
 
-        MultiTouchListener multiTouchListener = getMultiTouchListener();
+        MultiTouchListener multiTouchListener = getMultiTouchListener(isTextPinchScalable);
         multiTouchListener.setOnGestureControl(new MultiTouchListener.OnGestureControl() {
             @Override
             public void onClick() {
@@ -285,7 +285,7 @@ public class PhotoEditor implements BrushViewChangeListener {
         }
         emojiTextView.setTextSize(56);
         emojiTextView.setText(emojiName);
-        MultiTouchListener multiTouchListener = getMultiTouchListener();
+        MultiTouchListener multiTouchListener = getMultiTouchListener(true);
         multiTouchListener.setOnGestureControl(new MultiTouchListener.OnGestureControl() {
             @Override
             public void onClick() {
@@ -329,15 +329,16 @@ public class PhotoEditor implements BrushViewChangeListener {
     /**
      * Create a new instance and scalable touchview
      *
+     * @param isPinchScalable true if make pinch-scalable, false otherwise.
      * @return scalable multitouch listener
      */
     @NonNull
-    private MultiTouchListener getMultiTouchListener() {
+    private MultiTouchListener getMultiTouchListener(final boolean isPinchScalable) {
         MultiTouchListener multiTouchListener = new MultiTouchListener(
                 deleteView,
                 parentView,
                 this.imageView,
-                isTextPinchZoomable,
+                isPinchScalable,
                 mOnPhotoEditorListener,
                 this.viewState);
 
@@ -905,8 +906,8 @@ public class PhotoEditor implements BrushViewChangeListener {
         private BrushDrawingView brushDrawingView;
         private Typeface textTypeface;
         private Typeface emojiTypeface;
-        //By Default pinch zoom on text is enabled
-        private boolean isTextPinchZoomable = true;
+        // By default, pinch-to-scale is enabled for text
+        private boolean isTextPinchScalable = true;
 
         /**
          * Building a PhotoEditor which requires a Context and PhotoEditorView
@@ -950,13 +951,14 @@ public class PhotoEditor implements BrushViewChangeListener {
         }
 
         /**
-         * set false to disable pinch to zoom on text insertion.By deafult its true
+         * Set false to disable pinch-to-scale for text inserts.
+         * Set to "true" by default.
          *
-         * @param isTextPinchZoomable flag to make pinch to zoom
+         * @param isTextPinchScalable flag to make pinch to zoom for text inserts.
          * @return {@link Builder} instant to build {@link PhotoEditor}
          */
-        public Builder setPinchTextScalable(boolean isTextPinchZoomable) {
-            this.isTextPinchZoomable = isTextPinchZoomable;
+        public Builder setPinchTextScalable(boolean isTextPinchScalable) {
+            this.isTextPinchScalable = isTextPinchScalable;
             return this;
         }
 


### PR DESCRIPTION
Fixes #345 :

- Makes "setTextPinchScalable" only disable pinch scaling for text. Right now it disables it for text, emoji, and stickers.
- Adds a test for the above
- Adds a helper to allow for espresso pinch tests
- Fixes a NPE that would happen when an intent would have a null Action
- Renames internal variables to be consistent with PhotoEditor.Builder flag name (scalable vs zoomable)