### PR TITLE
Solution to Bitmap not available when needed for Draw on buildBitmap

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.java
@@ -305,7 +305,7 @@ class PhotoEditorImpl implements PhotoEditor {
                 PhotoSaverTask photoSaverTask = new PhotoSaverTask(parentView, mBoxHelper);
                 photoSaverTask.setOnSaveListener(onSaveListener);
                 photoSaverTask.setSaveSettings(saveSettings);
-                photoSaverTask.execute(imagePath);
+                photoSaverTask.saveFile(imagePath);
             }
 
             @Override

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoSaverTask.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoSaverTask.java
@@ -6,7 +6,6 @@ import android.graphics.Canvas;
 import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -102,16 +101,16 @@ class PhotoSaverTask extends AsyncTask<String, String, PhotoSaverTask.SaveResult
     }
 
     private Bitmap buildBitmap() {
+        // Create a new canvas with the content of the editor
+        Canvas canvas = new Canvas(mBaseBitmap);
 
         // This is needed as the mBaseBitmap may not be already ready to be drawed on
         boolean greenFlag = false;
         while (!greenFlag) {
             try {
-                mPhotoEditorView.draw(new Canvas(mBaseBitmap));
+                mPhotoEditorView.draw(canvas);
                 greenFlag = true;
-            } catch (IndexOutOfBoundsException i) {
-                Log.i("Draw", "Bitmap not ready. Retrying...");
-            }
+            } catch (Exception ignored) {}
         }
 
         return mSaveSettings.isTransparencyEnabled()

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoSaverTask.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoSaverTask.java
@@ -100,9 +100,20 @@ class PhotoSaverTask extends AsyncTask<String, String, PhotoSaverTask.SaveResult
     }
 
     private Bitmap buildBitmap() {
+        int height = mPhotoEditorView.getHeight();
+        int width = mPhotoEditorView.getWidth();
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+
+        try {
+            bitmap.prepareToDraw();
+            Thread.sleep(mSaveSettings.getDelayBeforeSaving());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         return mSaveSettings.isTransparencyEnabled()
-                ? BitmapUtil.removeTransparency(captureView(mPhotoEditorView))
-                : captureView(mPhotoEditorView);
+                ? BitmapUtil.removeTransparency(captureView(mPhotoEditorView, bitmap))
+                : captureView(mPhotoEditorView, bitmap);
     }
 
     @Override
@@ -151,14 +162,8 @@ class PhotoSaverTask extends AsyncTask<String, String, PhotoSaverTask.SaveResult
         }
     }
 
-    private Bitmap captureView(View view) {
-        Bitmap bitmap = Bitmap.createBitmap(
-                view.getWidth(),
-                view.getHeight(),
-                Bitmap.Config.ARGB_8888
-        );
-        Canvas canvas = new Canvas(bitmap);
-        view.draw(canvas);
+    private Bitmap captureView(View view, Bitmap bitmap) {
+        view.draw(new Canvas(bitmap));
         return bitmap;
     }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveSettings.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveSettings.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 public class SaveSettings {
     private boolean isTransparencyEnabled;
     private boolean isClearViewsEnabled;
+    private int delayBeforeSaving;
     private Bitmap.CompressFormat compressFormat;
     private int compressQuality;
 
@@ -31,9 +32,12 @@ public class SaveSettings {
         return compressQuality;
     }
 
+    int getDelayBeforeSaving() { return delayBeforeSaving; }
+
     private SaveSettings(Builder builder) {
         this.isClearViewsEnabled = builder.isClearViewsEnabled;
         this.isTransparencyEnabled = builder.isTransparencyEnabled;
+        this.delayBeforeSaving = builder.delayBeforeSaving;
         this.compressFormat = builder.compressFormat;
         this.compressQuality = builder.compressQuality;
     }
@@ -41,6 +45,7 @@ public class SaveSettings {
     public static class Builder {
         private boolean isTransparencyEnabled = true;
         private boolean isClearViewsEnabled = true;
+        private int delayBeforeSaving = 0;
         private Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.PNG;
         private int compressQuality = 100;
 
@@ -64,6 +69,17 @@ public class SaveSettings {
          */
         public Builder setClearViewsEnabled(boolean clearViewsEnabled) {
             isClearViewsEnabled = clearViewsEnabled;
+            return this;
+        }
+
+        /**
+         * Define a delay between creating the final Bitmap and drawing inside it's canvas
+         *
+         * @param delayBeforeSavingMs in milliseconds , that is the time delayed
+         * @return Int
+         */
+        public Builder setDelayBeforeSaving(int delayBeforeSavingMs) {
+            delayBeforeSaving = delayBeforeSavingMs;
             return this;
         }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveSettings.java
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveSettings.java
@@ -12,7 +12,6 @@ import androidx.annotation.NonNull;
 public class SaveSettings {
     private boolean isTransparencyEnabled;
     private boolean isClearViewsEnabled;
-    private int delayBeforeSaving;
     private Bitmap.CompressFormat compressFormat;
     private int compressQuality;
 
@@ -32,12 +31,9 @@ public class SaveSettings {
         return compressQuality;
     }
 
-    int getDelayBeforeSaving() { return delayBeforeSaving; }
-
     private SaveSettings(Builder builder) {
         this.isClearViewsEnabled = builder.isClearViewsEnabled;
         this.isTransparencyEnabled = builder.isTransparencyEnabled;
-        this.delayBeforeSaving = builder.delayBeforeSaving;
         this.compressFormat = builder.compressFormat;
         this.compressQuality = builder.compressQuality;
     }
@@ -45,7 +41,6 @@ public class SaveSettings {
     public static class Builder {
         private boolean isTransparencyEnabled = true;
         private boolean isClearViewsEnabled = true;
-        private int delayBeforeSaving = 0;
         private Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.PNG;
         private int compressQuality = 100;
 
@@ -69,17 +64,6 @@ public class SaveSettings {
          */
         public Builder setClearViewsEnabled(boolean clearViewsEnabled) {
             isClearViewsEnabled = clearViewsEnabled;
-            return this;
-        }
-
-        /**
-         * Define a delay between creating the final Bitmap and drawing inside it's canvas
-         *
-         * @param delayBeforeSavingMs in milliseconds , that is the time delayed
-         * @return Int
-         */
-        public Builder setDelayBeforeSaving(int delayBeforeSavingMs) {
-            delayBeforeSaving = delayBeforeSavingMs;
             return this;
         }
 

--- a/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/SaveSettingsTest.java
+++ b/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/SaveSettingsTest.java
@@ -48,16 +48,7 @@ public class SaveSettingsTest {
         assertFalse(saveSettings.isClearViewsEnabled());
         assertFalse(saveSettings.isTransparencyEnabled());
     }
-
-    @Test
-    public void testDelayBeforeSavingSaveSettings() {
-        SaveSettings saveSettings = new SaveSettings.Builder()
-            .setDelayBeforeSaving(1500)
-            .build();
-
-        assertEquals(saveSettings.getDelayBeforeSaving(), 1500);
-    }
-
+    
     @Test
     public void testDefaultCompressAndQualitySaveSettings() {
         SaveSettings saveSettings = new SaveSettings.Builder()

--- a/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/SaveSettingsTest.java
+++ b/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/SaveSettingsTest.java
@@ -50,6 +50,15 @@ public class SaveSettingsTest {
     }
 
     @Test
+    public void testDelayBeforeSavingSaveSettings() {
+        SaveSettings saveSettings = new SaveSettings.Builder()
+            .setDelayBeforeSaving(1500)
+            .build();
+
+        assertEquals(saveSettings.getDelayBeforeSaving(), 1500);
+    }
+
+    @Test
     public void testDefaultCompressAndQualitySaveSettings() {
         SaveSettings saveSettings = new SaveSettings.Builder()
                 .build();


### PR DESCRIPTION
Issue #374 forced me to try to understand what was happening that was breaking the save of Bitmaps.

It happens that in PhotoSaverTask.java in captureView(view) method a blank Bitmap is generated, and used in a new Canvas to be filled by the PhotoeditorView.

It seems that if this process happens too quickly, the Bitmap can't be generated quickly enough to be used, so it crashes everything.

I finally understood the main issue when I was debugging and when in RUN mode it would crash, but not in DEBUG mode.... JUST BECAUSE the debugger "pauses" when asked, giving it time in background to end the bitmap creation.

So I added an optional delay (default is ZERO, ok?) that enters just after the bitmap object creation, and before it's subsequential use.

Also, I removed the bitmap object blank creation from inside captureView, as we want it to be created as soon as possible and as far as possible from it's final use.

so... in SaveSettings, we now can set how many milliseconds between creating the createBitmap and the draw.