### PR TITLE
PE-439: Rename PhotoEdtiorView and update types in PhotoEditor

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BoxHelper.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BoxHelper.kt
@@ -1,7 +1,6 @@
 package ja.burhanrashid52.photoeditor
 
 import android.view.View
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ImageView
 
@@ -11,12 +10,12 @@ import android.widget.ImageView
  * @author <https:></https:>//github.com/burhanrashid52>
  */
 internal class BoxHelper(
-    private val mViewGroup: ViewGroup,
+    private val mPhotoEditorView: PhotoEditorView,
     private val mViewState: PhotoEditorViewState
 ) {
     fun clearHelperBox() {
-        for (i in 0 until mViewGroup.childCount) {
-            val childAt = mViewGroup.getChildAt(i)
+        for (i in 0 until mPhotoEditorView.childCount) {
+            val childAt = mPhotoEditorView.getChildAt(i)
             val frmBorder = childAt.findViewById<FrameLayout>(R.id.frmBorder)
             frmBorder?.setBackgroundResource(0)
             val imgClose = childAt.findViewById<ImageView>(R.id.imgPhotoEditorClose)
@@ -27,11 +26,11 @@ internal class BoxHelper(
 
     fun clearAllViews(drawingView: DrawingView?) {
         for (i in 0 until mViewState.addedViewsCount) {
-            mViewGroup.removeView(mViewState.getAddedView(i))
+            mPhotoEditorView.removeView(mViewState.getAddedView(i))
         }
         drawingView?.let {
             if (mViewState.containsAddedView(it)) {
-                mViewGroup.addView(it)
+                mPhotoEditorView.addView(it)
             }
         }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Emoji.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Emoji.kt
@@ -3,7 +3,6 @@ package ja.burhanrashid52.photoeditor
 import android.graphics.Typeface
 import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 
 /**
@@ -12,7 +11,7 @@ import android.widget.TextView
  * @author <https:></https:>//github.com/burhanrashid52>
  */
 internal class Emoji(
-    private val mPhotoEditorView: ViewGroup,
+    private val mPhotoEditorView: PhotoEditorView,
     private val mMultiTouchListener: MultiTouchListener,
     private val mViewState: PhotoEditorViewState,
     graphicManager: GraphicManager?,

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Graphic.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Graphic.kt
@@ -3,7 +3,6 @@ package ja.burhanrashid52.photoeditor
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.ImageView
 import ja.burhanrashid52.photoeditor.MultiTouchListener.OnGestureControl
 
@@ -55,10 +54,10 @@ internal abstract class Graphic(
     }
 
     protected fun buildGestureController(
-        viewGroup: ViewGroup,
+        photoEditorView: PhotoEditorView,
         viewState: PhotoEditorViewState
     ): OnGestureControl {
-        val boxHelper = BoxHelper(viewGroup, viewState)
+        val boxHelper = BoxHelper(photoEditorView, viewState)
         return object : OnGestureControl {
             override fun onClick() {
                 boxHelper.clearHelperBox()

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/GraphicManager.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/GraphicManager.kt
@@ -10,7 +10,7 @@ import android.widget.RelativeLayout
  * @author <https:></https:>//github.com/burhanrashid52>
  */
 internal class GraphicManager(
-    private val mViewGroup: ViewGroup,
+    private val mPhotoEditorView: PhotoEditorView,
     private val mViewState: PhotoEditorViewState
 ) {
     var onPhotoEditorListener: OnPhotoEditorListener? = null
@@ -20,7 +20,7 @@ internal class GraphicManager(
             ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT
         )
         params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE)
-        mViewGroup.addView(view, params)
+        mPhotoEditorView.addView(view, params)
         mViewState.addAddedView(view)
 
         onPhotoEditorListener?.onAddViewListener(
@@ -32,7 +32,7 @@ internal class GraphicManager(
     fun removeView(graphic: Graphic) {
         val view = graphic.rootView
         if (mViewState.containsAddedView(view)) {
-            mViewGroup.removeView(view)
+            mPhotoEditorView.removeView(view)
             mViewState.removeAddedView(view)
             mViewState.pushRedoView(view)
             onPhotoEditorListener?.onRemoveViewListener(
@@ -43,7 +43,7 @@ internal class GraphicManager(
     }
 
     fun updateView(view: View) {
-        mViewGroup.updateViewLayout(view, view.layoutParams)
+        mPhotoEditorView.updateViewLayout(view, view.layoutParams)
         mViewState.replaceAddedView(view)
     }
 
@@ -56,7 +56,7 @@ internal class GraphicManager(
                 return removeView.undo()
             } else {
                 mViewState.removeAddedView(mViewState.addedViewsCount - 1)
-                mViewGroup.removeView(removeView)
+                mPhotoEditorView.removeView(removeView)
                 mViewState.pushRedoView(removeView)
             }
             when (val viewTag = removeView.tag) {
@@ -78,7 +78,7 @@ internal class GraphicManager(
                 return redoView.redo()
             } else {
                 mViewState.popRedoView()
-                mViewGroup.addView(redoView)
+                mPhotoEditorView.addView(redoView)
                 mViewState.addAddedView(redoView)
             }
             when (val viewTag = redoView.tag) {

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/MultiTouchListener.kt
@@ -7,7 +7,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnTouchListener
 import android.widget.ImageView
-import android.widget.RelativeLayout
 import kotlin.math.max
 import kotlin.math.min
 
@@ -20,7 +19,7 @@ import kotlin.math.min
  */
 internal class MultiTouchListener(
     deleteView: View?,
-    parentView: RelativeLayout,
+    photoEditorView: PhotoEditorView,
     photoEditImageView: ImageView?,
     private val mIsPinchScalable: Boolean,
     onPhotoEditorListener: OnPhotoEditorListener?,
@@ -42,7 +41,7 @@ internal class MultiTouchListener(
     private var outRect: Rect? = null
     private val deleteView: View?
     private val photoEditImageView: ImageView?
-    private val parentView: RelativeLayout
+    private val photoEditorView: PhotoEditorView
     private var onMultiTouchListener: OnMultiTouchListener? = null
     private var mOnGestureControl: OnGestureControl? = null
     private val mOnPhotoEditorListener: OnPhotoEditorListener?
@@ -252,7 +251,7 @@ internal class MultiTouchListener(
         mScaleGestureDetector = ScaleGestureDetector(ScaleGestureListener())
         mGestureListener = GestureDetector(GestureListener())
         this.deleteView = deleteView
-        this.parentView = parentView
+        this.photoEditorView = photoEditorView
         this.photoEditImageView = photoEditImageView
         mOnPhotoEditorListener = onPhotoEditorListener
         outRect = if (deleteView != null) {

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
@@ -284,7 +284,7 @@ interface PhotoEditor {
     /**
      * Builder pattern to define [PhotoEditor] Instance
      */
-    class Builder(var context: Context, var parentView: PhotoEditorView) {
+    class Builder(var context: Context, var photoEditorView: PhotoEditorView) {
         @JvmField
         var imageView: ImageView? = null
         @JvmField
@@ -365,8 +365,8 @@ interface PhotoEditor {
          * @param photoEditorView [PhotoEditorView]
          */
         init {
-            imageView = parentView?.source
-            drawingView = parentView?.drawingView
+            imageView = photoEditorView?.source
+            drawingView = photoEditorView?.drawingView
         }
     }
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
@@ -31,24 +31,24 @@ import ja.burhanrashid52.photoeditor.shape.ShapeBuilder
 internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") constructor(
     builder: PhotoEditor.Builder
 ) : PhotoEditor {
-    private val parentView: PhotoEditorView = builder.parentView
+    private val photoEditorView: PhotoEditorView = builder.photoEditorView
     private val viewState: PhotoEditorViewState = PhotoEditorViewState()
     private val imageView: ImageView? = builder.imageView
     private val deleteView: View? = builder.deleteView
     private val drawingView: DrawingView? = builder.drawingView
     private val mBrushDrawingStateListener: BrushDrawingStateListener =
-        BrushDrawingStateListener(builder.parentView, viewState)
-    private val mBoxHelper: BoxHelper = BoxHelper(builder.parentView, viewState)
+        BrushDrawingStateListener(builder.photoEditorView, viewState)
+    private val mBoxHelper: BoxHelper = BoxHelper(builder.photoEditorView, viewState)
     private var mOnPhotoEditorListener: OnPhotoEditorListener? = null
     private val isTextPinchScalable: Boolean = builder.isTextPinchScalable
     private val mDefaultTextTypeface: Typeface? = builder.textTypeface
     private val mDefaultEmojiTypeface: Typeface? = builder.emojiTypeface
-    private val mGraphicManager: GraphicManager = GraphicManager(builder.parentView, viewState)
+    private val mGraphicManager: GraphicManager = GraphicManager(builder.photoEditorView, viewState)
     private val context: Context = builder.context
 
     override fun addImage(desiredImage: Bitmap?) {
         val multiTouchListener = getMultiTouchListener(true)
-        val sticker = Sticker(parentView, multiTouchListener, viewState, mGraphicManager)
+        val sticker = Sticker(photoEditorView, multiTouchListener, viewState, mGraphicManager)
         sticker.buildView(desiredImage)
         addToEditor(sticker)
     }
@@ -70,7 +70,7 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         drawingView?.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(isTextPinchScalable)
         val textGraphic =
-            Text(parentView, multiTouchListener, viewState, mDefaultTextTypeface, mGraphicManager)
+            Text(photoEditorView, multiTouchListener, viewState, mDefaultTextTypeface, mGraphicManager)
         textGraphic.buildView(text, styleBuilder)
         addToEditor(textGraphic)
     }
@@ -108,7 +108,7 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         drawingView?.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(true)
         val emoji =
-            Emoji(parentView, multiTouchListener, viewState, mGraphicManager, mDefaultEmojiTypeface)
+            Emoji(photoEditorView, multiTouchListener, viewState, mGraphicManager, mDefaultEmojiTypeface)
         emoji.buildView(emojiTypeface, emojiName)
         addToEditor(emoji)
     }
@@ -129,7 +129,7 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
     private fun getMultiTouchListener(isPinchScalable: Boolean): MultiTouchListener {
         return MultiTouchListener(
             deleteView,
-            parentView,
+            photoEditorView,
             imageView,
             isPinchScalable,
             mOnPhotoEditorListener,
@@ -189,11 +189,11 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
     }
 
     override fun setFilterEffect(customEffect: CustomEffect?) {
-        parentView.setFilterEffect(customEffect)
+        photoEditorView.setFilterEffect(customEffect)
     }
 
     override fun setFilterEffect(filterType: PhotoFilter?) {
-        parentView.setFilterEffect(filterType)
+        photoEditorView.setFilterEffect(filterType)
     }
 
     @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
@@ -208,9 +208,9 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         onSaveListener: OnSaveListener
     ) {
         Log.d(TAG, "Image Path: $imagePath")
-        parentView.saveFilter(object : OnSaveBitmap {
+        photoEditorView.saveFilter(object : OnSaveBitmap {
             override fun onBitmapReady(saveBitmap: Bitmap?) {
-                val photoSaverTask = PhotoSaverTask(parentView, mBoxHelper)
+                val photoSaverTask = PhotoSaverTask(photoEditorView, mBoxHelper)
                 photoSaverTask.setOnSaveListener(onSaveListener)
                 photoSaverTask.setSaveSettings(saveSettings)
                 photoSaverTask.execute(imagePath)
@@ -233,9 +233,9 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         saveSettings: SaveSettings,
         onSaveBitmap: OnSaveBitmap
     ) {
-        parentView.saveFilter(object : OnSaveBitmap {
+        photoEditorView.saveFilter(object : OnSaveBitmap {
             override fun onBitmapReady(saveBitmap: Bitmap?) {
-                val photoSaverTask = PhotoSaverTask(parentView, mBoxHelper)
+                val photoSaverTask = PhotoSaverTask(photoEditorView, mBoxHelper)
                 photoSaverTask.setOnSaveBitmap(onSaveBitmap)
                 photoSaverTask.setSaveSettings(saveSettings)
                 photoSaverTask.saveBitmap()
@@ -282,6 +282,6 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
             mOnPhotoEditorListener?.onTouchSourceImage(event)
             mDetector.onTouchEvent(event)
         }
-        parentView.setClipSourceImage(builder.clipSourceImage)
+        photoEditorView.setClipSourceImage(builder.clipSourceImage)
     }
 }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Sticker.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Sticker.kt
@@ -2,7 +2,6 @@ package ja.burhanrashid52.photoeditor
 
 import android.graphics.Bitmap
 import android.view.View
-import android.view.ViewGroup
 import android.widget.ImageView
 
 /**
@@ -11,7 +10,7 @@ import android.widget.ImageView
  * @author <https:></https:>//github.com/burhanrashid52>
  */
 internal class Sticker(
-    private val mPhotoEditorView: ViewGroup,
+    private val mPhotoEditorView: PhotoEditorView,
     private val mMultiTouchListener: MultiTouchListener,
     private val mViewState: PhotoEditorViewState,
     graphicManager: GraphicManager?

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Text.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/Text.kt
@@ -3,7 +3,6 @@ package ja.burhanrashid52.photoeditor
 import android.graphics.Typeface
 import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 
 /**
@@ -12,7 +11,7 @@ import android.widget.TextView
  * @author <https:></https:>//github.com/burhanrashid52>
  */
 internal class Text(
-    private val mPhotoEditorView: ViewGroup,
+    private val mPhotoEditorView: PhotoEditorView,
     private val mMultiTouchListener: MultiTouchListener,
     private val mViewState: PhotoEditorViewState,
     private val mDefaultTextTypeface: Typeface?,

--- a/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/GraphicManagerTest.kt
+++ b/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/GraphicManagerTest.kt
@@ -1,15 +1,11 @@
 package ja.burhanrashid52.photoeditor
 
 import android.content.Context
-import android.view.View
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-import android.view.ViewGroup
 import androidx.test.core.app.ApplicationProvider
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
-import org.junit.Assert
 import org.junit.Test
 
 /**
@@ -26,10 +22,8 @@ class GraphicManagerTest {
     fun testGraphicMangerAddViews() {
         val id = R.layout.view_photo_editor_text
         val childId = R.id.frmBorder
-        val viewGroup: ViewGroup = object : ViewGroup(mContext) {
-            override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {}
-        }
-        val graphicManager = GraphicManager(viewGroup, PhotoEditorViewState())
+        val photoEditorView = PhotoEditorView(mContext)
+        val graphicManager = GraphicManager(photoEditorView, PhotoEditorViewState())
         val graphic: Graphic = object : Graphic(
             context = mContext,
             layoutId = id,
@@ -39,7 +33,10 @@ class GraphicManagerTest {
 
         }
         graphicManager.addView(graphic)
-        assertEquals(viewGroup.childCount.toLong(), 1)
-        assertNotNull(viewGroup.findViewById(childId))
+
+        // NOTE(lucianocheng): Expect 4 views: Image, Filter, Brush,
+        //                     and the Graphic we just added.
+        assertEquals(4, photoEditorView.childCount.toLong())
+        assertNotNull(photoEditorView.findViewById(childId))
     }
 }


### PR DESCRIPTION
There are a handful of places where the `PhotoEditorView` has the identifier `viewGroup` or `parentView` in the codebase.

There are also places where it has the type `ViewGroup` or `RelativeView` rather than `PhotoEditorView`

This is endlessly confusing and makes the codebase less readable and robust. This ticket is to fix this.

Notes:

- This change is *inert*. It contains no functional changes.
- I did not update any names in the demo app, only in the library

See #439 