### PR TITLE
Replace AsyncTask with Kotlin coroutines when saving image

### DIFF
--- a/photoeditor/build.gradle
+++ b/photoeditor/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
     testImplementation 'androidx.test:core-ktx:1.5.0'
     testImplementation 'junit:junit:4.13.2'

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BitmapUtil.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BitmapUtil.kt
@@ -2,7 +2,6 @@ package ja.burhanrashid52.photoeditor
 
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.opengl.GLException
 import android.opengl.GLSurfaceView
 import java.nio.IntBuffer
 import javax.microedition.khronos.opengles.GL10
@@ -24,8 +23,7 @@ internal object BitmapUtil {
      * @param source edited image
      * @return bitmap without any transparency
      */
-    fun removeTransparency(source: Bitmap?): Bitmap? {
-        if (source == null) return source
+    fun removeTransparency(source: Bitmap): Bitmap {
         var firstX = 0
         var firstY = 0
         var lastX = source.width
@@ -76,7 +74,7 @@ internal object BitmapUtil {
      * @throws OutOfMemoryError error when system is out of memory to load and save bitmap
      */
     @Throws(OutOfMemoryError::class)
-    fun createBitmapFromGLSurface(glSurfaceView: GLSurfaceView, gl: GL10): Bitmap? {
+    fun createBitmapFromGLSurface(glSurfaceView: GLSurfaceView, gl: GL10): Bitmap {
         val x = 0
         val y = 0
         val w = glSurfaceView.width
@@ -85,23 +83,19 @@ internal object BitmapUtil {
         val bitmapSource = IntArray(w * h)
         val intBuffer = IntBuffer.wrap(bitmapBuffer)
         intBuffer.position(0)
-        try {
-            gl.glReadPixels(x, y, w, h, GL10.GL_RGBA, GL10.GL_UNSIGNED_BYTE, intBuffer)
-            var offset1: Int
-            var offset2: Int
-            for (i in 0 until h) {
-                offset1 = i * w
-                offset2 = (h - i - 1) * w
-                for (j in 0 until w) {
-                    val texturePixel = bitmapBuffer[offset1 + j]
-                    val blue = texturePixel shr 16 and 0xff
-                    val red = texturePixel shl 16 and 0x00ff0000
-                    val pixel = texturePixel and -0xff0100 or red or blue
-                    bitmapSource[offset2 + j] = pixel
-                }
+        gl.glReadPixels(x, y, w, h, GL10.GL_RGBA, GL10.GL_UNSIGNED_BYTE, intBuffer)
+        var offset1: Int
+        var offset2: Int
+        for (i in 0 until h) {
+            offset1 = i * w
+            offset2 = (h - i - 1) * w
+            for (j in 0 until w) {
+                val texturePixel = bitmapBuffer[offset1 + j]
+                val blue = texturePixel shr 16 and 0xff
+                val red = texturePixel shl 16 and 0x00ff0000
+                val pixel = texturePixel and -0xff0100 or red or blue
+                bitmapSource[offset2 + j] = pixel
             }
-        } catch (e: GLException) {
-            return null
         }
         return Bitmap.createBitmap(bitmapSource, w, h, Bitmap.Config.ARGB_8888)
     }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BitmapUtil.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BitmapUtil.kt
@@ -83,6 +83,7 @@ internal object BitmapUtil {
         val bitmapSource = IntArray(w * h)
         val intBuffer = IntBuffer.wrap(bitmapBuffer)
         intBuffer.position(0)
+
         gl.glReadPixels(x, y, w, h, GL10.GL_RGBA, GL10.GL_UNSIGNED_BYTE, intBuffer)
         var offset1: Int
         var offset2: Int
@@ -97,6 +98,8 @@ internal object BitmapUtil {
                 bitmapSource[offset2 + j] = pixel
             }
         }
+
         return Bitmap.createBitmap(bitmapSource, w, h, Bitmap.Config.ARGB_8888)
     }
+
 }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/ImageFilterView.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/ImageFilterView.kt
@@ -31,6 +31,7 @@ internal class ImageFilterView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : GLSurfaceView(context, attrs), GLSurfaceView.Renderer {
+
     private val mTextures = IntArray(2)
     private var mEffectContext: EffectContext? = null
     private var mEffect: Effect? = null
@@ -50,7 +51,7 @@ internal class ImageFilterView @JvmOverloads constructor(
         setFilterEffect(PhotoFilter.NONE)
     }
 
-    fun setSourceBitmap(sourceBitmap: Bitmap?) {
+    internal fun setSourceBitmap(sourceBitmap: Bitmap?) {
         /* if (mSourceBitmap != null && mSourceBitmap.sameAs(sourceBitmap)) {
             //mCurrentEffect = NONE;
         }*/
@@ -85,18 +86,18 @@ internal class ImageFilterView @JvmOverloads constructor(
         }
     }
 
-    fun setFilterEffect(effect: PhotoFilter) {
+    internal fun setFilterEffect(effect: PhotoFilter) {
         mCurrentEffect = effect
         mCustomEffect = null
         requestRender()
     }
 
-    fun setFilterEffect(customEffect: CustomEffect?) {
+    internal fun setFilterEffect(customEffect: CustomEffect?) {
         mCustomEffect = customEffect
         requestRender()
     }
 
-    fun saveBitmap(onBitmapReady: ((Bitmap) -> Unit)) {
+    internal fun saveBitmap(onBitmapReady: ((Bitmap) -> Unit)) {
         mOnBitmapReady = onBitmapReady
         requestRender()
     }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/OnSaveBitmap.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/OnSaveBitmap.kt
@@ -7,6 +7,7 @@ import android.graphics.Bitmap
  * @version 0.1.2
  * @since 5/21/2018
  */
+@Deprecated("This interface is deprecated and will be removed in a future release.")
 interface OnSaveBitmap {
     fun onBitmapReady(saveBitmap: Bitmap?)
     fun onFailure(e: Exception?)

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
@@ -223,49 +223,44 @@ interface PhotoEditor {
      * Save the edited image on given path
      *
      * @param imagePath      path on which image to be saved
-     * @param onSaveListener callback for saving image
-     * @see OnSaveListener
-     */
-    @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
-    fun saveAsFile(imagePath: String, onSaveListener: OnSaveListener)
-
-    /**
-     * Save the edited image on given path
-     *
-     * @param imagePath      path on which image to be saved
      * @param saveSettings   builder for multiple save options [SaveSettings]
-     * @param onSaveListener callback for saving image
-     * @see OnSaveListener
      */
-    @SuppressLint("StaticFieldLeak")
     @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
-    fun saveAsFile(
+    suspend fun saveAsFile(
         imagePath: String,
-        saveSettings: SaveSettings,
-        onSaveListener: OnSaveListener
-    )
-
-    /**
-     * Save the edited image as bitmap
-     *
-     * @param onSaveBitmap callback for saving image as bitmap
-     * @see OnSaveBitmap
-     */
-    @SuppressLint("StaticFieldLeak")
-    fun saveAsBitmap(onSaveBitmap: OnSaveBitmap)
+        saveSettings: SaveSettings = SaveSettings.Builder().build()
+    ): SaveFileResult
 
     /**
      * Save the edited image as bitmap
      *
      * @param saveSettings builder for multiple save options [SaveSettings]
-     * @param onSaveBitmap callback for saving image as bitmap
-     * @see OnSaveBitmap
      */
-    @SuppressLint("StaticFieldLeak")
-    fun saveAsBitmap(
-        saveSettings: SaveSettings,
-        onSaveBitmap: OnSaveBitmap
+    suspend fun saveAsBitmap(saveSettings: SaveSettings = SaveSettings.Builder().build()): Bitmap
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsFile(imagePath, saveSettings)")
     )
+    fun saveAsFile(imagePath: String, saveSettings: SaveSettings, onSaveListener: OnSaveListener)
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsFile(imagePath)")
+    )
+    fun saveAsFile(imagePath: String, onSaveListener: OnSaveListener)
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsBitmap(saveSettings)")
+    )
+    fun saveAsBitmap(saveSettings: SaveSettings, onSaveBitmap: OnSaveBitmap)
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsBitmap()")
+    )
+    fun saveAsBitmap(onSaveBitmap: OnSaveBitmap)
 
     /**
      * Callback on editing operation perform on [PhotoEditorView]
@@ -287,18 +282,23 @@ interface PhotoEditor {
     class Builder(var context: Context, var photoEditorView: PhotoEditorView) {
         @JvmField
         var imageView: ImageView? = null
+
         @JvmField
         var deleteView: View? = null
+
         @JvmField
         var drawingView: DrawingView? = null
+
         @JvmField
         var textTypeface: Typeface? = null
+
         @JvmField
         var emojiTypeface: Typeface? = null
 
         // By default, pinch-to-scale is enabled for text
         @JvmField
         var isTextPinchScalable = true
+
         @JvmField
         var clipSourceImage = false
         fun setDeleteView(deleteView: View?): Builder {
@@ -373,6 +373,7 @@ interface PhotoEditor {
     /**
      * A callback to save the edited image asynchronously
      */
+    @Deprecated("This interface is deprecated and will be removed in a future release.")
     interface OnSaveListener {
         /**
          * Call when edited image is saved successfully on given path
@@ -388,6 +389,7 @@ interface PhotoEditor {
          */
         fun onFailure(exception: Exception)
     }
+
     // region Shape
     /**
      * Update the current shape to be drawn,

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
@@ -73,14 +73,13 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
     override fun addText(text: String?, styleBuilder: TextStyleBuilder?) {
         drawingView?.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(isTextPinchScalable)
-        val textGraphic =
-            Text(
-                photoEditorView,
-                multiTouchListener,
-                viewState,
-                mDefaultTextTypeface,
-                mGraphicManager
-            )
+        val textGraphic = Text(
+            photoEditorView,
+            multiTouchListener,
+            viewState,
+            mDefaultTextTypeface,
+            mGraphicManager
+        )
         textGraphic.buildView(text, styleBuilder)
         addToEditor(textGraphic)
     }
@@ -117,14 +116,13 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
     override fun addEmoji(emojiTypeface: Typeface?, emojiName: String?) {
         drawingView?.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(true)
-        val emoji =
-            Emoji(
-                photoEditorView,
-                multiTouchListener,
-                viewState,
-                mGraphicManager,
-                mDefaultEmojiTypeface
-            )
+        val emoji = Emoji(
+            photoEditorView,
+            multiTouchListener,
+            viewState,
+            mGraphicManager,
+            mDefaultEmojiTypeface
+        )
         emoji.buildView(emojiTypeface, emojiName)
         addToEditor(emoji)
     }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
@@ -14,10 +14,8 @@ import androidx.annotation.IntRange
 import androidx.annotation.RequiresPermission
 import ja.burhanrashid52.photoeditor.PhotoEditorImageViewListener.OnSingleTapUpCallback
 import ja.burhanrashid52.photoeditor.shape.ShapeBuilder
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
@@ -6,16 +6,20 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Typeface
 import android.text.TextUtils
-import android.util.Log
 import android.view.GestureDetector
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.IntRange
 import androidx.annotation.RequiresPermission
-import ja.burhanrashid52.photoeditor.PhotoEditor.OnSaveListener
 import ja.burhanrashid52.photoeditor.PhotoEditorImageViewListener.OnSingleTapUpCallback
 import ja.burhanrashid52.photoeditor.shape.ShapeBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  *
@@ -70,7 +74,13 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         drawingView?.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(isTextPinchScalable)
         val textGraphic =
-            Text(photoEditorView, multiTouchListener, viewState, mDefaultTextTypeface, mGraphicManager)
+            Text(
+                photoEditorView,
+                multiTouchListener,
+                viewState,
+                mDefaultTextTypeface,
+                mGraphicManager
+            )
         textGraphic.buildView(text, styleBuilder)
         addToEditor(textGraphic)
     }
@@ -108,7 +118,13 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         drawingView?.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(true)
         val emoji =
-            Emoji(photoEditorView, multiTouchListener, viewState, mGraphicManager, mDefaultEmojiTypeface)
+            Emoji(
+                photoEditorView,
+                multiTouchListener,
+                viewState,
+                mGraphicManager,
+                mDefaultEmojiTypeface
+            )
         emoji.buildView(emojiTypeface, emojiName)
         addToEditor(emoji)
     }
@@ -197,54 +213,67 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
     }
 
     @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
-    override fun saveAsFile(imagePath: String, onSaveListener: OnSaveListener) {
-        saveAsFile(imagePath, SaveSettings.Builder().build(), onSaveListener)
+    override suspend fun saveAsFile(
+        imagePath: String,
+        saveSettings: SaveSettings
+    ): SaveFileResult = withContext(Dispatchers.Main) {
+        photoEditorView.saveFilter()
+        val photoSaverTask = PhotoSaverTask(photoEditorView, mBoxHelper, saveSettings)
+        return@withContext photoSaverTask.saveImageAsFile(imagePath)
     }
 
-    @SuppressLint("StaticFieldLeak")
+    override suspend fun saveAsBitmap(
+        saveSettings: SaveSettings
+    ): Bitmap = withContext(Dispatchers.Main) {
+        photoEditorView.saveFilter()
+        val photoSaverTask = PhotoSaverTask(photoEditorView, mBoxHelper, saveSettings)
+        return@withContext photoSaverTask.saveImageAsBitmap()
+    }
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsFile(imagePath, saveSettings)")
+    )
+    @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
     override fun saveAsFile(
         imagePath: String,
         saveSettings: SaveSettings,
-        onSaveListener: OnSaveListener
+        onSaveListener: PhotoEditor.OnSaveListener
     ) {
-        Log.d(TAG, "Image Path: $imagePath")
-        photoEditorView.saveFilter(object : OnSaveBitmap {
-            override fun onBitmapReady(saveBitmap: Bitmap?) {
-                val photoSaverTask = PhotoSaverTask(photoEditorView, mBoxHelper)
-                photoSaverTask.setOnSaveListener(onSaveListener)
-                photoSaverTask.setSaveSettings(saveSettings)
-                photoSaverTask.execute(imagePath)
+        GlobalScope.launch(Dispatchers.Main) {
+            when (val result = saveAsFile(imagePath, saveSettings)) {
+                is SaveFileResult.Success -> onSaveListener.onSuccess(imagePath)
+                is SaveFileResult.Failure -> onSaveListener.onFailure(result.exception)
             }
-
-            override fun onFailure(e: Exception?) {
-                e?.run {
-                    onSaveListener.onFailure(this)
-                }
-            }
-        })
+        }
     }
 
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsFile(imagePath)")
+    )
+    @RequiresPermission(allOf = [Manifest.permission.WRITE_EXTERNAL_STORAGE])
+    override fun saveAsFile(imagePath: String, onSaveListener: PhotoEditor.OnSaveListener) {
+        saveAsFile(imagePath, SaveSettings.Builder().build(), onSaveListener)
+    }
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsBitmap(saveSettings)")
+    )
+    override fun saveAsBitmap(saveSettings: SaveSettings, onSaveBitmap: OnSaveBitmap) {
+        GlobalScope.launch(Dispatchers.Main) {
+            val bitmap = saveAsBitmap(saveSettings)
+            onSaveBitmap.onBitmapReady(bitmap)
+        }
+    }
+
+    @Deprecated(
+        "This function is deprecated and will be removed in a future release.",
+        ReplaceWith("saveAsBitmap()")
+    )
     override fun saveAsBitmap(onSaveBitmap: OnSaveBitmap) {
         saveAsBitmap(SaveSettings.Builder().build(), onSaveBitmap)
-    }
-
-    @SuppressLint("StaticFieldLeak")
-    override fun saveAsBitmap(
-        saveSettings: SaveSettings,
-        onSaveBitmap: OnSaveBitmap
-    ) {
-        photoEditorView.saveFilter(object : OnSaveBitmap {
-            override fun onBitmapReady(saveBitmap: Bitmap?) {
-                val photoSaverTask = PhotoSaverTask(photoEditorView, mBoxHelper)
-                photoSaverTask.setOnSaveBitmap(onSaveBitmap)
-                photoSaverTask.setSaveSettings(saveSettings)
-                photoSaverTask.saveBitmap()
-            }
-
-            override fun onFailure(e: Exception?) {
-                onSaveBitmap.onFailure(e)
-            }
-        })
     }
 
     override fun setOnPhotoEditorListener(onPhotoEditorListener: OnPhotoEditorListener) {

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorView.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorView.kt
@@ -28,9 +28,12 @@ class PhotoEditorView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyle: Int = 0
 ) : RelativeLayout(context, attrs, defStyle) {
+
     private var mImgSource: FilterImageView = FilterImageView(context)
-    var drawingView: DrawingView
+
+    internal var drawingView: DrawingView
         private set
+
     private var mImageFilterView: ImageFilterView
     private var clipSourceImage = false
 
@@ -140,23 +143,23 @@ class PhotoEditorView @JvmOverloads constructor(
         }
     }
 
-    suspend fun saveFilter() = suspendCoroutine<Bitmap> { continuation ->
+    internal suspend fun saveFilter() = suspendCoroutine<Bitmap> { continuation ->
         saveFilter { continuation.resume(it) }
     }
 
-    fun setFilterEffect(filterType: PhotoFilter) {
+    internal fun setFilterEffect(filterType: PhotoFilter) {
         mImageFilterView.visibility = VISIBLE
         mImageFilterView.setSourceBitmap(mImgSource.bitmap)
         mImageFilterView.setFilterEffect(filterType)
     }
 
-    fun setFilterEffect(customEffect: CustomEffect?) {
+    internal fun setFilterEffect(customEffect: CustomEffect?) {
         mImageFilterView.visibility = VISIBLE
         mImageFilterView.setSourceBitmap(mImgSource.bitmap)
         mImageFilterView.setFilterEffect(customEffect)
     }
 
-    fun setClipSourceImage(clip: Boolean) {
+    internal fun setClipSourceImage(clip: Boolean) {
         clipSourceImage = clip
         val param = setupImageSource(null)
         mImgSource.layoutParams = param

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoSaverTask.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoSaverTask.kt
@@ -1,15 +1,11 @@
 package ja.burhanrashid52.photoeditor
 
-import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.os.AsyncTask
-import android.text.TextUtils
-import android.util.Log
 import android.view.View
 import ja.burhanrashid52.photoeditor.BitmapUtil.removeTransparency
-import ja.burhanrashid52.photoeditor.PhotoEditor.OnSaveListener
-import ja.burhanrashid52.photoeditor.PhotoSaverTask.SaveResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -19,144 +15,77 @@ import java.io.IOException
  *
  * @author <https:></https:>//github.com/burhanrashid52>
  */
-internal class PhotoSaverTask(photoEditorView: PhotoEditorView, boxHelper: BoxHelper) :
-    AsyncTask<String?, String?, SaveResult>() {
-    private var mSaveSettings: SaveSettings
-    private var mOnSaveListener: OnSaveListener? = null
-    private var mOnSaveBitmap: OnSaveBitmap? = null
-    private val mPhotoEditorView: PhotoEditorView?
-    private val mBoxHelper: BoxHelper
-    private val mDrawingView: DrawingView?
-    fun setOnSaveListener(onSaveListener: OnSaveListener?) {
-        mOnSaveListener = onSaveListener
+internal class PhotoSaverTask(
+    private val photoEditorView: PhotoEditorView,
+    private val boxHelper: BoxHelper,
+    private var saveSettings: SaveSettings
+) {
+
+    private val drawingView: DrawingView = photoEditorView.drawingView
+
+    private fun onBeforeSaveImage() {
+        boxHelper.clearHelperBox()
+        drawingView.destroyDrawingCache()
     }
 
-    fun setOnSaveBitmap(onSaveBitmap: OnSaveBitmap?) {
-        mOnSaveBitmap = onSaveBitmap
-    }
-
-    fun setSaveSettings(saveSettings: SaveSettings) {
-        mSaveSettings = saveSettings
-    }
-
-    override fun onPreExecute() {
-        super.onPreExecute()
-        mBoxHelper.clearHelperBox()
-        mDrawingView?.destroyDrawingCache()
-    }
-
-    @SuppressLint("MissingPermission")
-    override fun doInBackground(vararg inputs: String?): SaveResult {
-        // Create a media file name
-        return if (inputs.isEmpty()) {
-            saveImageAsBitmap()
-        } else {
-            saveImageInFile(inputs.first().toString())
+    fun saveImageAsBitmap(): Bitmap {
+        onBeforeSaveImage()
+        val bitmap = buildBitmap()
+        if (saveSettings.isClearViewsEnabled) {
+            boxHelper.clearAllViews(drawingView)
         }
+        return bitmap
     }
 
-    private fun saveImageAsBitmap(): SaveResult {
-        return SaveResult(null, null, buildBitmap())
-    }
+    suspend fun saveImageAsFile(imagePath: String): SaveFileResult {
+        onBeforeSaveImage()
+        val capturedBitmap = buildBitmap()
 
-    private fun saveImageInFile(mImagePath: String): SaveResult {
-        val file = File(mImagePath)
-        return try {
-            val out = FileOutputStream(file, false)
-            if (mPhotoEditorView != null) {
-                val capturedBitmap = buildBitmap()
-                capturedBitmap?.compress(
-                    mSaveSettings.compressFormat,
-                    mSaveSettings.compressQuality,
-                    out
-                )
+        val result = withContext(Dispatchers.IO) {
+            val file = File(imagePath)
+            try {
+                FileOutputStream(file, false).use { outputStream ->
+                    capturedBitmap.compress(
+                        saveSettings.compressFormat,
+                        saveSettings.compressQuality,
+                        outputStream
+                    )
+                    outputStream.flush()
+                }
+
+                SaveFileResult.Success
+            } catch (e: IOException) {
+                SaveFileResult.Failure(e)
             }
-            out.flush()
-            out.close()
-            Log.d(TAG, "Filed Saved Successfully")
-            SaveResult(null, mImagePath, null)
-        } catch (e: IOException) {
-            e.printStackTrace()
-            Log.e(TAG, "Failed to save File")
-            SaveResult(e, mImagePath, null)
         }
-    }
 
-    private fun buildBitmap(): Bitmap? {
-        return if (mSaveSettings.isTransparencyEnabled) removeTransparency(
-            captureView(mPhotoEditorView)
-        ) else captureView(mPhotoEditorView)
-    }
-
-    override fun onPostExecute(saveResult: SaveResult) {
-        super.onPostExecute(saveResult)
-        if (TextUtils.isEmpty(saveResult.mImagePath)) {
-            handleBitmapCallback(saveResult)
-        } else {
-            handleFileCallback(saveResult)
-        }
-    }
-
-    private fun handleFileCallback(saveResult: SaveResult) {
-        val exception = saveResult.mException
-        val imagePath = saveResult.mImagePath
-        if (exception == null) {
-            //Clear all views if its enabled in save settings
-            if (mSaveSettings.isClearViewsEnabled) {
-                mBoxHelper.clearAllViews(mDrawingView)
+        if (result is SaveFileResult.Success) {
+            // Clear all views if it's enabled in save settings
+            if (saveSettings.isClearViewsEnabled) {
+                boxHelper.clearAllViews(drawingView)
             }
-            assert(imagePath != null)
-            mOnSaveListener?.onSuccess(imagePath!!)
+        }
+
+        return result
+    }
+
+    private fun buildBitmap(): Bitmap {
+        return if (saveSettings.isTransparencyEnabled) {
+            removeTransparency(captureView(photoEditorView))
         } else {
-            mOnSaveListener?.onFailure(exception)
+            captureView(photoEditorView)
         }
     }
 
-    private fun handleBitmapCallback(saveResult: SaveResult) {
-        val bitmap = saveResult.mBitmap
-        if (bitmap != null) {
-            if (mSaveSettings.isClearViewsEnabled) {
-                mBoxHelper.clearAllViews(mDrawingView)
-            }
-            mOnSaveBitmap?.onBitmapReady(bitmap)
-
-        } else {
-            mOnSaveBitmap?.onFailure(Exception("Failed to load the bitmap"))
-        }
-    }
-
-    private fun captureView(view: View?): Bitmap? {
-        if (view == null) {
-            return null
-        }
-        val bitmap = Bitmap.createBitmap(
-            view.width,
-            view.height,
-            Bitmap.Config.ARGB_8888
-        )
+    private fun captureView(view: View): Bitmap {
+        val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         view.draw(canvas)
         return bitmap
     }
 
-    fun saveBitmap() {
-        execute()
-    }
-
-    internal class SaveResult(
-        val mException: Exception?,
-        val mImagePath: String?,
-        val mBitmap: Bitmap?
-    )
-
     companion object {
         const val TAG = "PhotoSaverTask"
     }
 
-    init {
-        mPhotoEditorView = photoEditorView
-        mDrawingView = photoEditorView.drawingView
-        mBoxHelper = boxHelper
-        mSaveSettings = SaveSettings.Builder().build()
-    }
 }

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveFileResult.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveFileResult.kt
@@ -1,0 +1,10 @@
+package ja.burhanrashid52.photoeditor
+
+import java.io.IOException
+
+sealed interface SaveFileResult {
+
+    object Success : SaveFileResult
+    class Failure(val exception: IOException) : SaveFileResult
+
+}


### PR DESCRIPTION
This commit replaces deprecated AsyncTask for saving images with Kotlin coroutines. Coroutines is Google's recommended solution for asynchronous programming on Android.

The commit also fixes a crash caused by View.draw() being called from worker thread when saving image (issue #374). As documentation says (https://developer.android.com/topic/performance/threads#references):

By design, Android View objects are not thread-safe. An app is expected to create, use, and destroy UI objects, all on the main thread. If you try to modify or even reference a UI object in a thread other than the main thread, the result can be exceptions, silent failures, crashes, and other undefined misbehavior.