### PR TITLE
Remove content description from imgPhotoEditorImage

### DIFF
--- a/photoeditor/src/main/res/layout/view_photo_editor_image.xml
+++ b/photoeditor/src/main/res/layout/view_photo_editor_image.xml
@@ -25,7 +25,6 @@
             android:layout_gravity="center"
             android:layout_margin="4dp"
             android:adjustViewBounds="true"
-            android:contentDescription="@string/app_name"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_remove" />
 


### PR DESCRIPTION
Content description should describe UI element for people with impaired vision. It is used by screen reader. In this case content description was the app's name, so it didn't provide any helpful information for screen reader. The reason I removed it instead of fix text is because we're not supporting languates other than english and french. On devices with other language, not translated text will fall back to english and it may be confusing.