### PR TITLE
Fix Builder methods' return type in Java

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveSettings.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/SaveSettings.kt
@@ -15,10 +15,10 @@ class SaveSettings private constructor(builder: Builder) {
     val compressQuality: Int
 
     class Builder {
-        var isTransparencyEnabled = true
-        var isClearViewsEnabled = true
-        var compressFormat = CompressFormat.PNG
-        var compressQuality = 100
+        @JvmField var isTransparencyEnabled = true
+        @JvmField var isClearViewsEnabled = true
+        @JvmField var compressFormat = CompressFormat.PNG
+        @JvmField var compressQuality = 100
 
         /**
          * Define a flag to enable transparency while saving image


### PR DESCRIPTION
I noticed that `SaveSetting.Builder`'s method properly return itself in Kotlin but return void in Java instead.
I figured out the issue.
When you define a mutable property in Kotlin, the compiler automatically generates a getter and setter method for it under the hood. It happens that the implicitly generated setter has the same name as the correct setter, so the correct setter gets "overwritten".
Let's take the `isTransparencyEnabled` property as an example. Since it is a mutable property (var), getter and setter methods are automatically generated (`isTransparencyEnabled()` as getter and `setTransparencyEnabled()` as setter). Since the `Builder` already has a `setTransparencyEnabled()` method (which returns the builder), the property's generated `setTransparencyEnabled()` method (which returns `void`) overwrites the `Builder` returning method.
The least disruptive solution I can think of is to mark the `Builder`'s field as `@JvmField` to still allow Kotlin callers to access the properties (for whatever reason), while fixing the issue for Java callers.