### PR TITLE
Fix clearing redo stack after brush drawing

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BrushDrawingStateListener.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/BrushDrawingStateListener.kt
@@ -47,6 +47,9 @@ class BrushDrawingStateListener internal constructor(
     }
 
     override fun onStopDrawing() {
+        if (mViewState.redoViewsCount > 0) {
+            mViewState.clearRedoViews()
+        }
         mOnPhotoEditorListener?.onStopViewChangeListener(ViewType.BRUSH_DRAWING)
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/burhanrashid52/PhotoEditor/pull/545#discussion_r1499095552, when drawing a new shape, the redo history should be cleared. #545 invokes `PhotoEditorViewState.clearRedoViews()` only when adding sticker, emoji or text. However, for brush drawing, the function is not invoked, leading to an incorrect value being returned by `PhotoEditorViewState.redoViewsCount`.