### PR TITLE
"setBrushEraserSize" size is not working as expected

### DIFF
--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/DrawingView.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/DrawingView.kt
@@ -66,6 +66,7 @@ class DrawingView @JvmOverloads constructor(
     private fun createEraserPaint(): Paint {
         val paint = createPaint()
         paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+        paint.strokeWidth = eraserSize
         return paint
     }
 


### PR DESCRIPTION
Using value from `eraserSize` as stroke width when creating eraser paint.