### PR TITLE
Add shapePaintStyle to ShapeBuilder

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,5 @@
 jdk:
   - openjdk17
-install:
-  - ./gradlew :photoeditor:publishToMavenLocal -x signReleasePublication
+before_install:
+  - sed -i "s|apply from.*publish-mavencentral.gradle.*||" photoeditor/build.gradle
+  - sed -i "/apply plugin: 'signing'/d" photoeditor/build.gradle

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk17
+install:
+  - ./gradlew :photoeditor:publishToMavenLocal -x signReleasePublication

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/DrawingView.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/DrawingView.kt
@@ -46,7 +46,7 @@ class DrawingView @JvmOverloads constructor(
         val paint = Paint()
         paint.isAntiAlias = true
         paint.isDither = true
-        paint.style = Paint.Style.STROKE
+        paint.style = currentShapeBuilder.shapePaintStyle
         paint.strokeJoin = Paint.Join.ROUND
         paint.strokeCap = Paint.Cap.ROUND
         paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_OVER)

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/shape/ShapeBuilder.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/shape/ShapeBuilder.kt
@@ -1,6 +1,7 @@
 package ja.burhanrashid52.photoeditor.shape
 
 import android.graphics.Color
+import android.graphics.Paint
 import androidx.annotation.ColorInt
 
 /**
@@ -26,6 +27,9 @@ class ShapeBuilder {
     var shapeColor: Int = DEFAULT_SHAPE_COLOR
         private set
 
+    var shapePaintStyle: Paint.Style = Paint.Style.STROKE
+        private set
+
     fun withShapeType(shapeType: ShapeType): ShapeBuilder {
         this.shapeType = shapeType
         return this
@@ -48,6 +52,11 @@ class ShapeBuilder {
 
     fun withShapeColor(@ColorInt color: Int): ShapeBuilder {
         shapeColor = color
+        return this
+    }
+
+    fun withShapePaintStyle(style: Paint.Style): ShapeBuilder {
+        shapePaintStyle = style
         return this
     }
 


### PR DESCRIPTION
Allow configuring Paint.Style (STROKE, FILL, FILL_AND_STROKE) on shapes via ShapeBuilder.withShapePaintStyle(). Defaults to STROKE for backward compatibility.