### PR TITLE
Unify PhotoEditor.addText API for Kotlin default parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Logs
 
 ## 3.1.1
-- New : Add `Position` and `PhotoEditor.addText(..., position)` overloads for initial text placement
+- New : Add optional `Position` support to the canonical `PhotoEditor.addText` API for initial text placement
 - New : Sample app now lets users tap the image to place text before entering it
 - Test : Add targeted placement coverage in `GraphicManagerTest` and update sample app test flow for tap-to-place text
 - Docs : Update `README.md` with developer API usage and end-user sample app instructions, including adding multiple text labels

--- a/README.md
+++ b/README.md
@@ -151,17 +151,40 @@ For more details check [Custom Filters](https://github.com/burhanrashid52/PhotoE
 
 ![](https://i.imgur.com/491BmE8.gif)
 
-We can add the text with inputText and colorCode like this
+Use `addText` with named optional parameters:
 
-`mPhotoEditor.addText(inputText, colorCode);` 
+```kotlin
+photoEditor.addText(
+    text = inputText,
+    colorCodeTextView = colorCode
+)
+```
 
-It will take default fonts provided in the builder. If we want different fonts for different text we can set typeface with each text like this
+It uses the default font from the builder unless you provide a typeface:
 
-`mPhotoEditor.addText(mTypeface,inputText, colorCode);`
+```kotlin
+photoEditor.addText(
+    text = inputText,
+    textTypeface = mTypeface,
+    colorCodeTextView = colorCode
+)
+```
 
-If you want the text to start at a specific location instead of the default centered position, use the overload with a `Position`:
+To place text away from the default centre position, provide a `Position`:
 
-`mPhotoEditor.addText(inputText, colorCode, new Position(80, 160));`
+```kotlin
+photoEditor.addText(
+    text = inputText,
+    position = Position(80, 160),
+    colorCodeTextView = colorCode
+)
+```
+
+Java callers must provide all parameters explicitly:
+
+```java
+mPhotoEditor.addText(inputText, null, new Position(80, 160), null, colorCode);
+```
 
 After insertion, text can still be dragged, rotated, and scaled on the canvas.
 

--- a/app/src/main/java/com/burhanrashid52/photoediting/EditImageActivity.kt
+++ b/app/src/main/java/com/burhanrashid52/photoediting/EditImageActivity.kt
@@ -524,7 +524,11 @@ class EditImageActivity : BaseActivity(), OnPhotoEditorListener, View.OnClickLis
             override fun onDone(inputText: String, colorCode: Int) {
                 val styleBuilder = TextStyleBuilder()
                 styleBuilder.withTextColor(colorCode)
-                mPhotoEditor.addText(inputText, styleBuilder, position)
+                mPhotoEditor.addText(
+                    text = inputText,
+                    styleBuilder = styleBuilder,
+                    position = position
+                )
                 mTxtCurrentTool.setText(R.string.label_text)
             }
         })

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
@@ -27,84 +27,23 @@ interface PhotoEditor {
     fun addImage(desiredImage: Bitmap)
 
     /**
-     * This add the text on the [PhotoEditorView] with provided parameters
+     * Adds text to the [PhotoEditorView].
      * by default [TextView.setText] will be 18sp
      *
      * @param text              text to display
-     * @param colorCodeTextView text color to be displayed
-     */
-    @SuppressLint("ClickableViewAccessibility")
-    fun addText(text: String, colorCodeTextView: Int)
-
-    /**
-     * This adds the text on the [PhotoEditorView] at the provided initial [position].
-     * by default [TextView.setText] will be 18sp
-     * The default interface implementation preserves backward binary compatibility by
-     * delegating to the centered overload, so custom implementations should override this
-     * method to honor [position].
-     *
-     * @param text              text to display
-     * @param colorCodeTextView text color to be displayed
+     * @param styleBuilder      text style builder with your style
      * @param position          initial position in pixels from the top-left of the editor
+     * @param textTypeface      typeface to apply when [styleBuilder] is not provided
+     * @param colorCodeTextView text color to apply when [styleBuilder] is not provided
      */
     @SuppressLint("ClickableViewAccessibility")
-    fun addText(text: String, colorCodeTextView: Int, position: Position) {
-        addText(text, colorCodeTextView)
-    }
-
-    /**
-     * This add the text on the [PhotoEditorView] with provided parameters
-     * by default [TextView.setText] will be 18sp
-     *
-     * @param textTypeface      typeface for custom font in the text
-     * @param text              text to display
-     * @param colorCodeTextView text color to be displayed
-     */
-    @SuppressLint("ClickableViewAccessibility")
-    fun addText(textTypeface: Typeface?, text: String, colorCodeTextView: Int)
-
-    /**
-     * This adds the text on the [PhotoEditorView] at the provided initial [position].
-     * by default [TextView.setText] will be 18sp
-     * The default interface implementation preserves backward binary compatibility by
-     * delegating to the centered overload, so custom implementations should override this
-     * method to honor [position].
-     *
-     * @param textTypeface      typeface for custom font in the text
-     * @param text              text to display
-     * @param colorCodeTextView text color to be displayed
-     * @param position          initial position in pixels from the top-left of the editor
-     */
-    @SuppressLint("ClickableViewAccessibility")
-    fun addText(textTypeface: Typeface?, text: String, colorCodeTextView: Int, position: Position) {
-        addText(textTypeface, text, colorCodeTextView)
-    }
-
-    /**
-     * This add the text on the [PhotoEditorView] with provided parameters
-     * by default [TextView.setText] will be 18sp
-     *
-     * @param text         text to display
-     * @param styleBuilder text style builder with your style
-     */
-    @SuppressLint("ClickableViewAccessibility")
-    fun addText(text: String, styleBuilder: TextStyleBuilder?)
-
-    /**
-     * This adds the text on the [PhotoEditorView] at the provided initial [position].
-     * by default [TextView.setText] will be 18sp
-     * The default interface implementation preserves backward binary compatibility by
-     * delegating to the centered overload, so custom implementations should override this
-     * method to honor [position].
-     *
-     * @param text         text to display
-     * @param styleBuilder text style builder with your style
-     * @param position     initial position in pixels from the top-left of the editor
-     */
-    @SuppressLint("ClickableViewAccessibility")
-    fun addText(text: String, styleBuilder: TextStyleBuilder?, position: Position) {
-        addText(text, styleBuilder)
-    }
+    fun addText(
+        text: String,
+        styleBuilder: TextStyleBuilder? = null,
+        position: Position? = null,
+        textTypeface: Typeface? = null,
+        colorCodeTextView: Int? = null
+    )
 
     /**
      * This will update text and color on provided view

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditor.kt
@@ -27,14 +27,18 @@ interface PhotoEditor {
     fun addImage(desiredImage: Bitmap)
 
     /**
-     * Adds text to the [PhotoEditorView].
-     * by default [TextView.setText] will be 18sp
+     * Adds text to the [PhotoEditorView]. By default [TextView.setText] will be 18sp and the
+     * text is centred in the editor.
+     *
+     * A supplied [styleBuilder] is applied as-is. When it is not supplied, a style is created
+     * from [textTypeface] and [colorCodeTextView] when either value is provided.
      *
      * @param text              text to display
-     * @param styleBuilder      text style builder with your style
-     * @param position          initial position in pixels from the top-left of the editor
-     * @param textTypeface      typeface to apply when [styleBuilder] is not provided
-     * @param colorCodeTextView text color to apply when [styleBuilder] is not provided
+     * @param styleBuilder      text style builder to apply as-is
+     * @param position          initial position in pixels from the top-left of the editor; `null`
+     *                          centres the text
+     * @param textTypeface      typeface for the text when [styleBuilder] is not provided
+     * @param colorCodeTextView text color when [styleBuilder] is not provided
      */
     @SuppressLint("ClickableViewAccessibility")
     fun addText(

--- a/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
+++ b/photoeditor/src/main/java/ja/burhanrashid52/photoeditor/PhotoEditorImpl.kt
@@ -55,49 +55,24 @@ internal class PhotoEditorImpl @SuppressLint("ClickableViewAccessibility") const
         addToEditor(sticker)
     }
 
-    override fun addText(text: String, colorCodeTextView: Int) {
-        addText(null, text, colorCodeTextView)
-    }
-
-    override fun addText(text: String, colorCodeTextView: Int, position: Position) {
-        addText(null, text, colorCodeTextView, position)
-    }
-
-    override fun addText(textTypeface: Typeface?, text: String, colorCodeTextView: Int) {
-        val styleBuilder = TextStyleBuilder()
-        styleBuilder.withTextColor(colorCodeTextView)
-        if (textTypeface != null) {
-            styleBuilder.withTextFont(textTypeface)
-        }
-        addTextInternal(text, styleBuilder)
-    }
-
     override fun addText(
-        textTypeface: Typeface?,
         text: String,
-        colorCodeTextView: Int,
-        position: Position
+        styleBuilder: TextStyleBuilder?,
+        position: Position?,
+        textTypeface: Typeface?,
+        colorCodeTextView: Int?
     ) {
-        val styleBuilder = TextStyleBuilder()
-        styleBuilder.withTextColor(colorCodeTextView)
-        if (textTypeface != null) {
-            styleBuilder.withTextFont(textTypeface)
+        val finalStyleBuilder = styleBuilder ?: TextStyleBuilder().apply {
+            textTypeface?.let(::withTextFont)
+            colorCodeTextView?.let(::withTextColor)
         }
-        addTextInternal(text, styleBuilder, position)
-    }
-
-    override fun addText(text: String, styleBuilder: TextStyleBuilder?) {
-        addTextInternal(text, styleBuilder)
-    }
-
-    override fun addText(text: String, styleBuilder: TextStyleBuilder?, position: Position) {
-        addTextInternal(text, styleBuilder, position)
+        addTextInternal(text, finalStyleBuilder, position)
     }
 
     private fun addTextInternal(
         text: String,
         styleBuilder: TextStyleBuilder?,
-        position: Position? = null
+        position: Position?
     ) {
         drawingView.enableDrawing(false)
         val multiTouchListener = getMultiTouchListener(isTextPinchScalable)

--- a/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/PhotoEditorImplTest.kt
+++ b/photoeditor/src/test/java/ja/burhanrashid52/photoeditor/PhotoEditorImplTest.kt
@@ -1,0 +1,83 @@
+package ja.burhanrashid52.photoeditor
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.view.View
+import android.widget.RelativeLayout
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PhotoEditorImplTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun addTextUsesDefaultStyleAndCenteredPosition() {
+        val photoEditorView = PhotoEditorView(context)
+        val photoEditor = PhotoEditor.Builder(context, photoEditorView).build()
+
+        photoEditor.addText(text = "Default text")
+
+        val textView = textView(photoEditorView)
+        val params = textRoot(textView).layoutParams as RelativeLayout.LayoutParams
+        assertEquals("Default text", textView.text)
+        assertEquals(RelativeLayout.TRUE, params.getRule(RelativeLayout.CENTER_IN_PARENT))
+    }
+
+    @Test
+    fun addTextUsesProvidedStyleBuilderUnchanged() {
+        val photoEditorView = PhotoEditorView(context)
+        val photoEditor = PhotoEditor.Builder(context, photoEditorView).build()
+        val styleBuilder = TextStyleBuilder().apply {
+            withTextColor(Color.MAGENTA)
+            withTextFont(Typeface.SERIF)
+        }
+
+        photoEditor.addText(
+            text = "Styled text",
+            styleBuilder = styleBuilder,
+            textTypeface = Typeface.DEFAULT_BOLD,
+            colorCodeTextView = Color.BLUE
+        )
+
+        val textView = textView(photoEditorView)
+        assertEquals(Color.MAGENTA, textView.currentTextColor)
+        assertEquals(Typeface.SERIF, textView.typeface)
+    }
+
+    @Test
+    fun addTextBuildsStyleAndUsesExplicitPosition() {
+        val photoEditorView = PhotoEditorView(context)
+        val photoEditor = PhotoEditor.Builder(context, photoEditorView).build()
+
+        photoEditor.addText(
+            text = "Positioned text",
+            position = Position(x = 42, y = 84),
+            textTypeface = Typeface.DEFAULT_BOLD,
+            colorCodeTextView = Color.BLUE
+        )
+
+        val textView = textView(photoEditorView)
+        val params = textRoot(textView).layoutParams as RelativeLayout.LayoutParams
+        assertEquals(Color.BLUE, textView.currentTextColor)
+        assertEquals(Typeface.DEFAULT_BOLD, textView.typeface)
+        assertEquals(42, params.leftMargin)
+        assertEquals(84, params.topMargin)
+        assertFalse(params.getRule(RelativeLayout.CENTER_IN_PARENT) == RelativeLayout.TRUE)
+    }
+
+    private fun textView(photoEditorView: PhotoEditorView): TextView {
+        return photoEditorView.findViewById(R.id.tvPhotoEditorText)
+    }
+
+    private fun textRoot(textView: TextView): View {
+        return (textView.parent as View).parent as View
+    }
+}


### PR DESCRIPTION
Closes #594.

Implements the canonical Kotlin `addText` API described in #594, including call-site migrations and documentation updates.

## Compatibility

This is the requested Kotlin-first refactor. Java callers now use the documented full five-parameter method.

## Tests

Passed:

```text
./gradlew --no-daemon :photoeditor:testDebugUnitTest \
  --tests ja.burhanrashid52.photoeditor.PhotoEditorImplTest \
  --tests ja.burhanrashid52.photoeditor.GraphicManagerTest
```

`BUILD SUCCESSFUL`.